### PR TITLE
[재현] 쪽지함 UI 작업  

### DIFF
--- a/src/component/organism/list/NoteMessageList.js
+++ b/src/component/organism/list/NoteMessageList.js
@@ -13,35 +13,33 @@ import UserNote from '../listitem/UserNote';
  * @param {boolean} props.checkBoxMode - 선택 삭제 모드 여부 (default= false)
  * @param {boolean} props.showFollowBtn - 선택 삭제 모드 여부 (default= false)
  */
-const NoteList = props => {
-	console.log('NoteList props', props.data);
+const NoteMessageList = props => {
+	console.log('NoteMessageList props', props.data);
 	const renderItem = ({item, index}) => {
 		console.log('item', item);
+		//쪽지부분 정책 결정 필요
 		return (
 			<View style={[accountHashList.userAccount]}>
-				<UserNote
+				{/* <UserNote
 					data={item}
 					checkBoxMode={props.checkBoxMode}
 					onLabelClick={item => props.onClickLabel(item)}
 					onCheckBox={e => props.onCheckBox(e, index)}
-				/>
+				/> */}
 			</View>
 		);
 	};
 
 	return (
 		<View style={[accountHashList.container, {height: props.routeName && props.routeName != 'SaveFavorite' ? 300 * DP : null}]}>
+			<Text>쪽지 내용 리스트 나오는 화면</Text>
 			<FlatList data={props.data} keyExtractor={item => item._id} renderItem={renderItem} showsVerticalScrollIndicator={false} />
 		</View>
 	);
 };
 
-NoteList.defaultProps = {
+NoteMessageList.defaultProps = {
 	items: [],
-	onClickLabel: e => console.log(e),
-	onCheckBox: e => console.log(e),
-	checkBoxMode: false, // CheckBox 콘테이너 Show T/F
-	showFollowBtn: false,
 };
 
-export default NoteList;
+export default NoteMessageList;

--- a/src/component/organism/list/NoteSelectStat.js
+++ b/src/component/organism/list/NoteSelectStat.js
@@ -58,9 +58,9 @@ const NoteSelectStat = props => {
 				) : (
 					<TouchableOpacity style={[temp_style.textBtn]} onPress={props.changeStatus}>
 						{props.received ? (
-							<Text style={[txt.noto26, {color: APRI10}, {alignSelf: 'flex-start'}]}>받은 쪽지함</Text>
-						) : (
 							<Text style={[txt.noto26, {color: APRI10}, {alignSelf: 'flex-start'}]}>보낸 쪽지함</Text>
+						) : (
+							<Text style={[txt.noto26, {color: APRI10}, {alignSelf: 'flex-start'}]}>받은 쪽지함</Text>
 						)}
 					</TouchableOpacity>
 				)}

--- a/src/component/organism/listitem/UserNote.js
+++ b/src/component/organism/listitem/UserNote.js
@@ -24,9 +24,6 @@ const UserNote = props => {
 
 	return (
 		<View style={[styles.userNoteContainer]}>
-			{/* {console.log(`props.checkBoxMode=>${props.checkBoxMode}`)}
-			{console.log(`props.data.checkBoxState=>${props.data.checkBoxState}`)} */}
-			{/* CheckBox */}
 			{props.checkBoxMode ? (
 				<View style={[userAccount.checkBox]}>
 					<CheckBox
@@ -39,7 +36,7 @@ const UserNote = props => {
 			)}
 			{/* 메모 썸네일 객체 */}
 			<View style={[styles.userNoteContainer]}>
-				<TouchableOpacity>
+				<TouchableOpacity onPress={() => props.onLabelClick(data)}>
 					<View style={[styles.userNoteThumbnail]}>
 						{data.user_profile_uri != undefined ? (
 							<Image source={{uri: data.user_profile_uri}} style={[styles.img_round_94]} />

--- a/src/component/templete/user/ReceivedMessage.js
+++ b/src/component/templete/user/ReceivedMessage.js
@@ -1,15 +1,15 @@
 import {useNavigation} from '@react-navigation/core';
 import React from 'react';
-import {Text, View, ScrollView, TouchableOpacity, TextInput, ActivityIndicator, StyleSheet} from 'react-native';
+import {Text, View, ScrollView, TouchableOpacity, TextInput, ActivityIndicator, StyleSheet, TouchableWithoutFeedback} from 'react-native';
 import {GRAY10, GRAY40, APRI10, GRAY20, TEXTBASECOLOR} from 'Root/config/color';
 import {txt} from 'Root/config/textstyle';
 import {userLogout} from 'Root/api/userapi';
 import DP from 'Root/config/dp';
 import userGlobalObject from 'Root/config/userGlobalObject';
-import {login_style, temp_style} from '../style_templete';
+import {login_style, temp_style, feedWrite} from '../style_templete';
 import NoteSelectStat from 'Root/component/organism/list/NoteSelectStat';
 import NoteList from 'Root/component/organism/list/NoteList';
-
+import {Message94, Urgent_Write1, Urgent_Write2} from 'Root/component/atom/icon';
 export default ReceivedMessage = ({route}) => {
 	const dummyData = [
 		{
@@ -45,6 +45,21 @@ export default ReceivedMessage = ({route}) => {
 		received ? navigation.setOptions({title: '보낸 쪽지함'}) : navigation.setOptions({title: '받은 쪽지함'});
 		setReceived(!received);
 	};
+	//쪽지 보내기 모달
+	const onPressSendMsg = () => {
+		Modal.close();
+		setTimeout(() => {
+			Modal.popMessageModal(
+				'주둥이',
+				msg => {
+					console.log('msg', msg);
+					Modal.close();
+				},
+				() => alert('나가기'),
+			);
+		}, 100);
+	};
+
 	//Check Box On
 	const showCheckBox = e => {
 		console.log(`showCheckBox=>${showCheckBox}`);
@@ -60,7 +75,9 @@ export default ReceivedMessage = ({route}) => {
 		setData(copy);
 	};
 	const onClickLabel = data => {
-		navigation.push('UserProfile', {userobject: data});
+		console.log('onCLick data', data);
+		// navigation.push('UserProfile', {userobject: data});
+		navigation.push('UserNote', {title: data.memobox_send_id, messageObject: data});
 	};
 
 	// 선택하기 => 전체 선택 클릭
@@ -84,9 +101,7 @@ export default ReceivedMessage = ({route}) => {
 		});
 		setData(copy);
 	};
-	const onClickFollow = data => {
-		console.log('data', data);
-	};
+
 	//CheckBox 클릭 시
 	const onCheckBox = (item, index) => {
 		let copy = [...data];
@@ -104,17 +119,14 @@ export default ReceivedMessage = ({route}) => {
 					received={received}
 					changeStatus={changeStatus}
 				/>
-				{/* <SelectStat /> */}
 			</View>
 			<View style={[styles.noteList, {height: null}]}>
-				<NoteList
-					data={data}
-					checkBoxMode={checkBoxMode}
-					onClickLabel={onClickLabel}
-					onClickFollow={onClickFollow}
-					onCheckBox={onCheckBox}
-					routeName={route.name}
-				/>
+				<NoteList data={data} checkBoxMode={checkBoxMode} onClickLabel={onClickLabel} onCheckBox={onCheckBox} routeName={route.name} />
+			</View>
+			<View style={[styles.messageBtnContainer]}>
+				<TouchableWithoutFeedback onPress={onPressSendMsg}>
+					<View style={[styles.messageActionButton]}>{checkBoxMode ? <Message94 /> : <Message94 />}</View>
+				</TouchableWithoutFeedback>
 			</View>
 		</View>
 	);
@@ -128,5 +140,32 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 		justifyContent: 'center',
 		// backgroundColor: '#F2C2C2',
+	},
+
+	messageBtnContainer: {
+		width: 94 * DP,
+		height: 94 * DP,
+		position: 'absolute',
+		right: 30 * DP,
+		bottom: 40 * DP,
+		justifyContent: 'flex-end',
+	},
+	messageActionButton: {
+		width: 94 * DP,
+		height: 94 * DP,
+		alignSelf: 'flex-end',
+		shadowColor: '#000000',
+		shadowOpacity: 0.3,
+		borderRadius: 100 * DP,
+		shadowOffset: {
+			width: 2,
+			height: 2,
+		},
+		shadowRadius: 3.65,
+		// shadowOffset: {
+		// 	width: 2 * DP,
+		// 	height: 1 * DP,
+		// },
+		elevation: 4,
 	},
 });

--- a/src/component/templete/user/SettingOpen.js
+++ b/src/component/templete/user/SettingOpen.js
@@ -11,6 +11,7 @@ import {getSettingPublic, updateSettingPublic} from 'Root/api/settingpublic';
 import {INFO_QUESTION} from 'Root/i18n/msg';
 import FastImage from 'react-native-fast-image';
 import {useState} from 'react/cjs/react.production.min';
+import SettingOpenPage from './SettingOpenPage';
 
 export default SettingOpen = ({route}) => {
 	const [openObject, setOpenObject] = React.useState();
@@ -49,6 +50,9 @@ export default SettingOpen = ({route}) => {
 			},
 		);
 	}, [openObject]);
+	React.useEffect(() => {
+		console.log('Refreshing', refreshing);
+	}, [refreshing]);
 	const onSwtichAll = () => {
 		if (openObject.setting_public_all) {
 			setOpenObject(prevState => ({

--- a/src/component/templete/user/UserNotePage.js
+++ b/src/component/templete/user/UserNotePage.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import {View, TouchableOpacity, Text, StyleSheet, Image} from 'react-native';
+import AniButton from 'Molecules/button/AniButton';
+import CheckBox from 'Molecules/select/CheckBox';
+import {userAccount} from 'Organism/style_organism copy';
+import {txt} from 'Root/config/textstyle';
+import DP from 'Root/config/dp';
+import {GRAY10, APRI10, BLACK, WHITE} from 'Root/config/color';
+import {getTimeLapsed} from 'Root/util/dateutil';
+import {textstyles} from '../style_templete';
+import {ScrollView} from 'react-native-gesture-handler';
+import NoteMessageList from 'Root/component/organism/list/NoteMessageList';
+/**
+ * 쪽지 썸네일 객체
+ * @param {object} props - Props Object
+ * @param {object} props.data - 쪽지 아이템 데이터
+ * @param {void} props.onLabelClick - 쪽지 라벨 클릭
+ * @param {boolean} props.checkBoxMode - 선택 삭제 모드 여부 (default = false)
+ * @param {boolean} props.checkBoxState - 선택 여부 (default = false)
+ */
+const UserNotePage = props => {
+	// console.log('UserAccount item', props.data);
+	const data = props.route.params.messageObject;
+	console.log('====================================');
+	console.log(data);
+	console.log('====================================');
+	return (
+		<View style={styles.container}>
+			<Text style={txt.noto24}>쪽지는 한 달 후에 자동 삭제됩니다.</Text>
+			<View style={styles.messageContainer}>
+				<NoteMessageList />
+			</View>
+		</View>
+	);
+};
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		alignItems: 'center',
+		backgroundColor: WHITE,
+	},
+	messageContainer: {
+		marginTop: 30 * DP,
+	},
+});
+
+// Us.defaultProps = {
+// 	onLabelClick: e => console.log(e),
+// 	onClickFollow: e => console.log(e),
+// 	onCheckBox: e => console.log(e),
+// 	checkBoxMode: false,
+// 	checkBoxState: false,
+// 	showFollowBtn: false,
+// };
+
+export default UserNotePage;

--- a/src/navigation/route/main_tab/my_stack/MyStackNavigation.js
+++ b/src/navigation/route/main_tab/my_stack/MyStackNavigation.js
@@ -64,6 +64,8 @@ import AlarmAndSearchHeader from 'Root/navigation/header/AlarmAndSearchHeader';
 import SimpleWithMeatballHeader from 'Root/navigation/header/SimpleWithMeatballHeader';
 import EditAidRequest from 'Root/component/templete/protection/EditAidRequest';
 import ReceivedMessage from 'Templete/user/ReceivedMessage';
+import UserNotePage from 'Templete/user/UserNotePage';
+
 const MyStack = createStackNavigator();
 export default MyStackNavigation = props => {
 	return (
@@ -311,6 +313,7 @@ export default MyStackNavigation = props => {
 				component={ReceivedMessage}
 				options={{header: props => <SimpleHeader {...props} />, title: '받은 쪽지함'}}
 			/>
+			<MyStack.Screen name="UserNote" component={UserNotePage} options={{header: props => <SimpleHeader {...props} />, title: props.title}} />
 		</MyStack.Navigator>
 	);
 };


### PR DESCRIPTION
*수정 사항: 마이 쪽지함, 쪽지 보내기 floating 버튼 추가, 유저와의 쪽지 내역 페이지 템플릿 추가했습니다. 
*수정 결과: floating버튼으로 쪽지 보내기 기능 modal 과 연결했습니다.   modal쪽 보내는 사용자 지정하는 부분의 작업이 필요합니다. 
유저와의 쪽지 내역 페이지 템플릿을 추가했습니다. 쪽지 정책관련 (UI측에서 어떤식으로 보여지는지 정확하게 정해진것 같지 않아서) 회의 후에 추후 작업 해야합니다. 

onoffswtich 리랜더링 관해서는 컴포넌트를 따로 만들어서 props로 전달하는 값을 참조하게 만들어보았는데도 클릭하지 않고 참조하는 값이 변하면 render가 다시 되지 않습니다. ㅠㅠ

* 수정 파일 
수정 
NoteList - 불필요한 코드 삭제 
NoteSelectStat - 문구 수정 
UserNote - onPress 함수 추가 
ReceivedMessage - 쪽지 보내기 floating button추가 
SettingOpen - 설정 onOff 리랜더링 시도(실패) 
MyStackNavigation - navigation 추가 
새로 추가 
NoteMessageList - 사용자 쪽지 대화내용 list 올가니즘 
UserNotePage - 사용자 쪽지 대화내용 템플릿 

