### PR TITLE
[재현] 메세지 보내기/  쪽지함 메세지 보낼시 reload/ 이용약관 페이지 UI 완성 /  문의내역 답변 UI

### DIFF
--- a/src/component/organism/listitem/OneNotice.js
+++ b/src/component/organism/listitem/OneNotice.js
@@ -1,7 +1,7 @@
 import {useNavigation} from '@react-navigation/core';
 import React from 'react';
 import {Text, View, ScrollView, TouchableOpacity, TextInput, ActivityIndicator, StyleSheet} from 'react-native';
-import {GRAY10, GRAY40, APRI10, GRAY20} from 'Root/config/color';
+import {GRAY10, GRAY40, APRI10, GRAY20, WHITE} from 'Root/config/color';
 import {txt} from 'Root/config/textstyle';
 import moment from 'moment';
 import DP from 'Root/config/dp';
@@ -47,6 +47,14 @@ const OneNotice = props => {
 			{pressed ? (
 				<View style={styles.noticeDetailContainer}>
 					<Text style={[styles.detailText]}>{props.contents}</Text>
+					{props.answered ? (
+						<View style={[styles.answeredContainer]}>
+							<Text style={[styles.answeredTextTitle, txt.noto28b, {color: GRAY10}]}>답변</Text>
+							<Text style={[styles.answeredText]}>{props.answerText}</Text>
+						</View>
+					) : (
+						<></>
+					)}
 				</View>
 			) : (
 				<></>
@@ -76,10 +84,27 @@ const styles = StyleSheet.create({
 		marginHorizontal: 48 * DP,
 		marginTop: 40 * DP,
 	},
+	answeredContainer: {
+		borderTopColor: WHITE,
+		borderTopWidth: 2 * DP,
+		backgroundColor: GRAY40,
+	},
+	answeredText: {
+		backgroundColor: GRAY40,
+		marginBottom: 40 * DP,
+		marginHorizontal: 48 * DP,
+	},
+	answeredTextTitle: {
+		backgroundColor: GRAY40,
+		marginHorizontal: 48 * DP,
+		marginTop: 30 * DP,
+	},
 });
 
 OneNotice.defaultProps = {
 	status: false,
+	answered: false,
+	answerText: null,
 };
 
 export default OneNotice;

--- a/src/component/templete/user/AskedQuestion.js
+++ b/src/component/templete/user/AskedQuestion.js
@@ -15,10 +15,12 @@ const AskedQuestion = ({route}) => {
 	const navigation = useNavigation();
 	const [data, setData] = React.useState();
 	const [loading, setLoading] = React.useState(true);
+	const [answerText, setAnswerText] = React.useState();
 	React.useEffect(() => {
 		getQandInfo(
 			{qanda_user_id: userGlobalObj.userInfo._id},
 			result => {
+				console.log('result', result);
 				setData(result.msg);
 				setLoading(false);
 			},
@@ -32,6 +34,8 @@ const AskedQuestion = ({route}) => {
 		console.log('item', item);
 		if (item.qanda_status == 'waiting') {
 			var answered = false;
+		} else {
+			var answered = true;
 		}
 		const date = moment(item.announcement_date).format('YYYY.MM.DD');
 		return (
@@ -41,6 +45,7 @@ const AskedQuestion = ({route}) => {
 				contents={item.qanda_question_contents}
 				status={true}
 				answered={answered}
+				answerText={item.qanda_answer_contents || null}
 			/>
 		);
 	};

--- a/src/component/templete/user/ReceivedMessage.js
+++ b/src/component/templete/user/ReceivedMessage.js
@@ -126,11 +126,11 @@ export default ReceivedMessage = ({route}) => {
 			<View style={[styles.noteList, {height: null}]}>
 				<NoteList data={data} checkBoxMode={checkBoxMode} onClickLabel={onClickLabel} onCheckBox={onCheckBox} routeName={route.name} />
 			</View>
-			<View style={[styles.messageBtnContainer]}>
+			{/* <View style={[styles.messageBtnContainer]}>
 				<TouchableWithoutFeedback onPress={onPressSendMsg}>
 					<View style={[styles.messageActionButton]}>{checkBoxMode ? <Message94 /> : <Message94 />}</View>
 				</TouchableWithoutFeedback>
-			</View>
+			</View> */}
 		</View>
 	);
 };

--- a/src/component/templete/user/SettingInformAsk.js
+++ b/src/component/templete/user/SettingInformAsk.js
@@ -17,16 +17,17 @@ export default SettingInformAsk = ({route}) => {
 	};
 
 	const onPressServiceTerms = () => {
-		Modal.popInfoModal();
+		// Modal.popInfoModal();
+		navigation.push('TermsAndPolicy', {name: 'service'});
 	};
 	const onPressLocationTerms = () => {
-		Modal.popInfoModal();
+		navigation.push('TermsAndPolicy', {name: 'location'});
 	};
 	const onPressPrivacyTerms = () => {
-		Modal.popInfoModal();
+		navigation.push('TermsAndPolicy', {name: 'privacy'});
 	};
 	const onPressOpenSource = () => {
-		Modal.popInfoModal();
+		navigation.push('TermsAndPolicy', {name: 'opensource'});
 	};
 
 	return (

--- a/src/component/templete/user/TermsAndPolicy.js
+++ b/src/component/templete/user/TermsAndPolicy.js
@@ -1,0 +1,68 @@
+import {useNavigation} from '@react-navigation/core';
+import React from 'react';
+import {Text, View, ScrollView, TouchableOpacity, TextInput, ActivityIndicator, StyleSheet} from 'react-native';
+import {GRAY10, GRAY40, APRI10, GRAY20} from 'Root/config/color';
+import {txt} from 'Root/config/textstyle';
+import DP from 'Root/config/dp';
+
+const dummyData = [
+	'서비스 이용약관 서비스 이용약관 서비스 이용약관서비스 이용약관서비스 이용약관서비스 이용약관서비스 이용약관서비스 이용약관서비스 이용약관',
+	'위치 정보 이용 약관 위치 정보 이용 약관위치 정보 이용 약관위치 정보 이용 약관위치 정보 이용 약관위치 정보 이용 약관위치 정보 이용 약관',
+	'개인 정보 처리 방침 개인 정보 처리 방침개인 정보 처리 방침개인 정보 처리 방침개인 정보 처리 방침개인 정보 처리 방침개인 정보 처리 방침개인 정보 처리 방침',
+	'오픈 소스 라이선스 정보 오픈 소스 라이선스 정보오픈 소스 라이선스 정보오픈 소스 라이선스 정보오픈 소스 라이선스 정보오픈 소스 라이선스 정보',
+];
+
+const TermsAndPolicy = ({route}) => {
+	const navigation = useNavigation();
+	console.log('route', route);
+	const [data, setData] = React.useState('');
+	React.useEffect(() => {
+		// console.log('route name', route.params.name);
+		switch (route.params.name) {
+			case 'service':
+				navigation.setOptions({title: '서비스 이용약관'});
+				setData(dummyData[0]);
+				break;
+			case 'location':
+				navigation.setOptions({title: '위치 정보 이용 약관'});
+				setData(dummyData[1]);
+				break;
+			case 'privacy':
+				navigation.setOptions({title: '개인정보처리 방침'});
+				setData(dummyData[2]);
+				break;
+			case 'opensource':
+				navigation.setOptions({title: '오픈소스 라이선스 정보'});
+				setData(dummyData[3]);
+		}
+	}, []);
+	return (
+		<View style={styles.container}>
+			<ScrollView style={styles.termsContainer}>
+				<Text>{data}</Text>
+			</ScrollView>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		width: 750 * DP,
+		height: 780 * DP,
+		marginTop: 10 * DP,
+		backgroundColor: '#FFFFFF',
+	},
+	noticeContainer: {
+		height: 128 * DP,
+		paddingLeft: 48 * DP,
+		justifyContent: 'center',
+		borderBottomColor: GRAY40,
+		borderBottomWidth: 2 * DP,
+	},
+	termsContainer: {
+		marginTop: 48 * DP,
+		marginHorizontal: 48 * DP,
+	},
+});
+export default TermsAndPolicy;

--- a/src/component/templete/user/UserNotePage.js
+++ b/src/component/templete/user/UserNotePage.js
@@ -31,7 +31,8 @@ const UserNotePage = ({route}) => {
 	const [loading, setLoading] = React.useState(true);
 	const input = React.useRef();
 	const [content, setContent] = React.useState('');
-
+	const [sent, setSent] = React.useState(false);
+	console.log('data', data);
 	React.useEffect(() => {
 		getMemoBoxWithReceiveID(
 			{user_object_id: route.params._id},
@@ -44,7 +45,7 @@ const UserNotePage = ({route}) => {
 				console.log('err', err);
 			},
 		);
-	}, []);
+	}, [sent]);
 	const [heightReply, setReplyHeight] = React.useState(0);
 	const onReplyBtnLayout = e => {
 		setReplyHeight(e.nativeEvent.layout.height);
@@ -55,6 +56,7 @@ const UserNotePage = ({route}) => {
 			{memobox_receive_id: route.params._id, memobox_contents: content},
 			result => {
 				console.log('message Sent', result);
+				setSent(!sent);
 			},
 			err => {
 				'message Sent err', err;
@@ -77,7 +79,7 @@ const UserNotePage = ({route}) => {
 				<View style={[styles.messageContainer]}>
 					<NoteMessageList data={data} />
 				</View>
-				<View style={{position: 'absolute', bottom: keyboardY}} onLayout={onReplyBtnLayout}>
+				<View style={[{position: 'absolute', bottom: keyboardY}, {backgroundColor: WHITE}]} onLayout={onReplyBtnLayout}>
 					<ReplyWriteBox onWrite={onWrite} onChangeReplyInput={onChangeReplyInput} ref={input} value={input} isMessage={true} />
 				</View>
 			</View>

--- a/src/navigation/route/main_tab/my_stack/MyStackNavigation.js
+++ b/src/navigation/route/main_tab/my_stack/MyStackNavigation.js
@@ -71,6 +71,7 @@ import QnA from 'Root/component/templete/user/AskQuestion';
 import CategoryHelp from 'Templete/user/CategoryHelp';
 import ServiceCenterTopTabNavigation from './ServiceCenterTopTabNavigation';
 import CategoryHelpTopTabNavigation from './CategoryHelpTopTabNavigation';
+import TermsAndPolicy from 'Root/component/templete/user/TermsAndPolicy';
 const MyStack = createStackNavigator();
 export default MyStackNavigation = props => {
 	return (
@@ -318,6 +319,7 @@ export default MyStackNavigation = props => {
 			<MyStack.Screen name="ServiceCenter" component={ServiceCenter} options={{header: props => <SimpleHeader {...props} />, title: '고객 센터'}} />
 			<MyStack.Screen name="CategoryHelp" component={CategoryHelp} options={{header: props => <AlarmAndSearchHeader {...props} />}} />
 			<MyStack.Screen name="ServiceTab" component={ServiceCenterTopTabNavigation} options={{header: props => <InputAndSearchHeader {...props} />}} />
+			<MyStack.Screen name="TermsAndPolicy" component={TermsAndPolicy} options={{header: props => <SimpleHeader {...props} />, title: '약관'}} />
 			<MyStack.Screen
 				name="CategoryHelpTab"
 				component={CategoryHelpTopTabNavigation}

--- a/src/navigation/route/main_tab/my_stack/ServiceCenterTopTabNavigation.js
+++ b/src/navigation/route/main_tab/my_stack/ServiceCenterTopTabNavigation.js
@@ -46,7 +46,11 @@ const ServiceCenterTopTabNavigation = ({route, navigation}) => {
 					</View>
 				); // gesture Handler(손가락으로 swipe)로 tab을 움직였을 시 자식까지 state를 연동시키기 위한 props
 			}}>
-			<ServiceCenterTab.Screen name="AskQuestion" component={AskQuestion} />
+			<ServiceCenterTab.Screen
+				name="AskQuestion"
+				component={AskQuestion}
+				options={{header: props => <SimpleHeader {...props} />, title: '문의사항'}}
+			/>
 			<ServiceCenterTab.Screen name="AskedList" component={AskedQuestion} />
 		</ServiceCenterTab.Navigator>
 	);


### PR DESCRIPTION
*수정 사항: MY-나의 반려동물 팝업 터쳐블 오류 (다른 항목인 경우 별도 커밋)
*수정 결과: 피드에서 쪽지 잘 보내집니다. 쪽지 보낼시 쪽지 리스트 reload 가능합니다. 문의하기/ 문의내역 header를 따로따로 줘야하는데 방법을 모르겠습니다. ㅠㅠ
*수정 파일: 
수정 
FeedContent- 메세지 보내기 모달
OneNotice - 문의하기 답변 부분 완료
AskedQuestion - 문의하기 답변완료 부분 구문 처리 
SettingInformAsk - 이용약관 분기처리 UI 제작 
UserNotePage - 메세지 보낸뒤에 data reload 로직 적용
MyStackNavigation - 스택 추가 
ServiceCenterTopTabNavigation - 문의하기 문의내역 header 따로 적용해야하지만 실패 
TermsAndPolicy - 이용약관 화면 templete 

추가해야 될것 - 
- UI적 몰리큘즈 부분/ 
- 자주 묻는 질문 처리
- 회원가입시 - createAnnouncement, createSettingPublic 각각 실행 하기 
