### PR TITLE
[재현] 알람 리프레쉬, UI 수정, 팔로우 알람 클릭시 프로필로 이동(오류있음)

### DIFF
--- a/src/component/molecules/input/InputWithSearchIcon.js
+++ b/src/component/molecules/input/InputWithSearchIcon.js
@@ -4,7 +4,7 @@ import {View, TouchableOpacity, TextInput} from 'react-native';
 import DP from 'Root/config/dp';
 import {APRI10, GRAY30} from 'Root/config/color';
 import {Cross24_Filled, Cross48, Search48} from 'Atom/icon';
-
+import searchContext from 'Root/config/searchContext';
 /**
  * 검색 기능이 추가된 인풋 컴포넌트
  * @param {object} props - Props Object

--- a/src/component/organism/list/DailyAlarm.js
+++ b/src/component/organism/list/DailyAlarm.js
@@ -18,13 +18,13 @@ import {GRAY40} from 'Root/config/color';
  */
 const stringList = ['오늘', '어제', '이번 주'];
 const DailyAlarm = props => {
-	console.log('Daily Alarm props', props.data, props.index);
-	console.log('newNote', props.index == 0 && props.newNote);
+	// console.log('Daily Alarm props', props.data, props.index);
+	// console.log('newNote', props.index == 0 && props.newNote);
 	const renderItem = ({item, index}) => {
-		console.log('item', item);
+		// console.log('item', item);
 		return (
 			<View style={[accountHashList.userAccount]}>
-				<OneAlarm data={item} onLabelClick={item => props.onClickLabel(item)} newNote={props.newNote} index={index} isData={props.isData} />
+				<OneAlarm data={item} onLabelClick={item => props.onLabelClick(item)} newNote={props.newNote} index={index} isData={props.isData} />
 			</View>
 		);
 	};
@@ -52,6 +52,8 @@ const styles = StyleSheet.create({
 		width: 750 * DP,
 		borderBottomColor: GRAY40,
 		borderBottomWidth: 2 * DP,
+		flexGrow: 0,
+		flex: 1,
 		// alignItems: 'center',
 	},
 	userContainer: {
@@ -60,13 +62,14 @@ const styles = StyleSheet.create({
 		marginBottom: 40 * DP,
 	},
 	listContainer: {
+		// flexGrow: 0,
 		flex: 1,
 	},
 });
 
 DailyAlarm.defaultProps = {
 	items: [],
-	onClickLabel: e => console.log(e),
+	// onClickLabel: e => console.log(e),
 	onCheckBox: e => console.log(e),
 	checkBoxMode: false, // CheckBox 콘테이너 Show T/F
 	showFollowBtn: false,

--- a/src/component/organism/listitem/OneAlarm.js
+++ b/src/component/organism/listitem/OneAlarm.js
@@ -8,6 +8,7 @@ import DP from 'Root/config/dp';
 import {GRAY10, APRI10, BLACK, APRI20, WHITE} from 'Root/config/color';
 import {getTimeLapsed} from 'Root/util/dateutil';
 import {ProfileDefaultImg} from 'Root/component/atom/icon';
+import {useNavigation} from '@react-navigation/core';
 /**
  * 알람 객체
  * @param {object} props - Props Object
@@ -23,9 +24,6 @@ const OneAlarm = props => {
 	const [isNewNote, setIsNewNote] = React.useState(false);
 	const data = props.data;
 	const [value, setValue] = React.useState(0);
-	console.log('props', props);
-	console.log('newNote', props.newNote, props.index);
-	// console.log('time', data.memobox_date);
 	const colors = ['#FF9888', WHITE];
 	React.useEffect(() => {
 		if (props.index == 0 && props.isData && props.newNote) {
@@ -39,7 +37,17 @@ const OneAlarm = props => {
 		}, 2000);
 		// clearTimeout(timer);
 	}, []);
-	console.log('OneAlarm props', data);
+	// const onLabelClick = data => {
+	// 	console.log(data.notice_user_collection, data);
+	// 	switch (data.notice_user_collection) {
+	// 		case 'comment':
+	// 			break;
+	// 		case 'follow':
+	// 			navigation.navigate('UserProfile', {userobject: data.notice_user_related_id});
+	// 			// navigation.push('UserProfile', {userobject: data.notice_user_related_id});
+	// 			break;
+	// 	}
+	// };
 	return (
 		<View style={[isNewNote ? [styles.yescontainer, {backgroundColor: colors[value]}] : styles.container]}>
 			<TouchableOpacity onPress={() => props.onLabelClick(data)}>
@@ -68,22 +76,34 @@ const OneAlarm = props => {
 	);
 };
 const styles = StyleSheet.create({
-	container: {width: 690 * DP, height: 134 * DP, justifyContent: 'center', marginLeft: 30 * DP, borderRadius: 30 * DP},
-	yescontainer: {
+	container: {
 		width: 690 * DP,
-		height: 134 * DP,
+		minHeight: 134 * DP,
 		justifyContent: 'center',
 		marginLeft: 30 * DP,
 		borderRadius: 30 * DP,
+		// flexGrow: 0, flex: 1
+	},
+	yescontainer: {
+		width: 690 * DP,
+		minHeight: 134 * DP,
+		justifyContent: 'center',
+		marginLeft: 30 * DP,
+		borderRadius: 30 * DP,
+		flexGrow: 0,
+		flex: 1,
 		// backgroundColor: colors[value],
 	},
 	userAlarmContainer: {
 		width: 654 * DP,
+		minHeight: 82 * DP,
 		// height: 94 * DP,
 		flexDirection: 'row',
 		marginLeft: 18 * DP,
 		// backgroundColor: '#F2C2C2',
 		// backgroundColor: 'yellow',
+		// flexGrow: 0,
+		// flex: 1,
 	},
 
 	img_round_94: {
@@ -93,13 +113,14 @@ const styles = StyleSheet.create({
 	},
 	noProfileMessage: {
 		width: 566 * DP,
-		height: 82 * DP,
+		minHeight: 82 * DP,
 	},
-	messageContainer: {width: 442 * DP, height: 82 * DP, marginLeft: 30 * DP, marginTop: 6 * DP},
+	messageContainer: {width: 442 * DP, minHeight: 82 * DP, marginLeft: 30 * DP, marginTop: 6 * DP},
 
 	timeBeforeContainer: {
 		// width: 110 * DP,
-		height: 44 * DP,
+		minHeight: 44 * DP,
+		marginLeft: 10 * DP,
 		// backgroundColor: 'yellow',
 		// marginRight: 48 * DP,
 		justifyContent: 'center',
@@ -108,7 +129,7 @@ const styles = StyleSheet.create({
 });
 
 UserAccount.defaultProps = {
-	onLabelClick: e => console.log(e),
+	// onLabelClick: e => console.log(e),
 	onClickFollow: e => console.log(e),
 	onCheckBox: e => console.log(e),
 	checkBoxMode: false,

--- a/src/component/templete/list/AlarmList.js
+++ b/src/component/templete/list/AlarmList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FlatList, ScrollView, Text, View, StyleSheet, SafeAreaView} from 'react-native';
+import {FlatList, ScrollView, Text, View, StyleSheet, SafeAreaView, ActivityIndicator, RefreshControl} from 'react-native';
 import UserAccount from 'Organism/listitem/UserAccount';
 import {accountHashList} from 'Organism/style_organism copy';
 import UserNote from '../../organism/listitem/UserNote';
@@ -7,53 +7,38 @@ import DailyAlarm from '../../organism/list/DailyAlarm';
 import {WHITE} from 'Root/config/color';
 import {getNoticeUserList} from 'Root/api/noticeuser';
 import _ from 'lodash';
-const dummyData = [
-	[
-		{
-			alarm_contents: '알람내용입니다.',
-			alarm_date: '2022-03-30T02:49:35.501Z',
-			alarm_receive_id: '623b17ed400ac30b877dd7d9',
-			opponent_user_profile_uri: 'https://pinetreegy.s3.ap-northeast-2.amazonaws.com/upload/1648045670715_812A892F-3DE8-4C38-96D8-2F6A6BC78091.jpg',
-			__v: 0,
-			_id: '6243c53fe8fde95d3b021a44',
-		},
-		{
-			alarm_contents: '알람내용입니다22.',
-			alarm_date: '2022-03-30T02:51:35.501Z',
-			alarm_receive_id: '623b17ed400ac30b877dd7d9',
-			opponent_user_profile_uri: 'https://pinetreegy.s3.ap-northeast-2.amazonaws.com/upload/1648045670715_812A892F-3DE8-4C38-96D8-2F6A6BC78091.jpg',
-			__v: 0,
-			_id: '6243c53fe8fde95d3b021a446',
-		},
-	],
-	[
-		{
-			alarm_contents: '와우222',
-			alarm_date: '2022-03-29T02:57:51.748Z',
-			alarm_receive_id: '61d2de63c0f179ccd5ba5887',
-			opponent_user_profile_uri: 'https://pinetreegy.s3.ap-northeast-2.amazonaws.com/upload/1647932305390_C0975042-AE19-4AF5-955F-F7EC597A67CB.jpg',
-			__v: 0,
-			_id: '624275afd1eff95f7778ba53',
-		},
-	],
-	[
-		{
-			alarm_contents: '그냥 텍스트',
-			alarm_date: '2022-03-29T02:58:51.748Z',
-			alarm_receive_id: '61d2de63c0f179ccd5ba5887',
-			__v: 0,
-			_id: '624275afd1eff95f7778ba55',
-		},
-	],
-];
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {temp_inputLongText} from 'Root/i18n/msg';
+import {lo} from '../style_address';
+import {getUserProfile} from 'Root/api/userapi';
+
+const wait = timeout => {
+	return new Promise(resolve => setTimeout(resolve, timeout));
+};
+
 const AlarmList = props => {
 	const [checkBoxMode, setCheckBoxMode] = React.useState(true);
-	const [newNote, setNewNote] = React.useState(true);
+	const [newNote, setNewNote] = React.useState(false);
 	const [data, setData] = React.useState();
 	const [isEmpty, setIsEmpty] = React.useState();
-	console.log('NoteList props', props.data);
+	const [loading, setLoading] = React.useState(true);
 	let count = 0;
+	const [refreshing, setRefreshing] = React.useState(false);
+	console.log('props', props);
+	const onRefresh = React.useCallback(() => {
+		setRefreshing(true);
+
+		wait(1000).then(() => getAlarmList());
+	}, []);
+
 	React.useEffect(() => {
+		getAlarmList();
+	}, []);
+	const getAlarmList = () => {
+		let asyncAlarm;
+		AsyncStorage.getItem('AlarmList', (err, result) => {
+			asyncAlarm = result;
+		});
 		let temp = [[], [], []];
 		getNoticeUserList(
 			{},
@@ -62,18 +47,46 @@ const AlarmList = props => {
 				temp[0] = [...result.msg.today];
 				temp[1] = [...result.msg.yesterday];
 				temp[2] = [...result.msg.thisweek];
-				console.log('temp', temp.length);
+				console.log('temp', temp[0].length, temp[1].length, temp[2].length);
 				setData(temp);
+				if (!_.isEqual(JSON.stringify(result.msg), asyncAlarm)) {
+					AsyncStorage.setItem('AlarmList', JSON.stringify(result.msg));
+					// console.log(asyncAlarm, '둘이 다르다');
+					setNewNote(true);
+				}
 				setIsEmpty(_.isEmpty(temp[0]) && _.isEmpty(temp[1]) && _.isEmpty(temp[2]));
+				setLoading(false);
+				setRefreshing(false);
 			},
 			err => {
 				console.log('getNoticeUserList err', err);
 			},
 		);
-	}, []);
+	};
+	const onLabelClick = data => {
+		console.log(data.notice_user_collection, data, 'zz');
+		switch (data.notice_user_collection) {
+			case 'comment':
+				break;
+			case 'follow':
+				getUserProfile(
+					{userobject_id: data.notice_user_related_id._id},
+					result => {
+						console.log('result', result.msg);
+						props.navigation.navigate('UserProfile', {userobject: result.msg});
+					},
+					err => {
+						console.log('err', err);
+					},
+				);
+				// navigation.navigate('UserProfile', {userobject: data.notice_user_related_id});
+				// props.navigation.push('UserProfile', {userobject: data.notice_user_related_id});
+				break;
+		}
+	};
 
 	const renderItem = ({item, index}) => {
-		console.log('item', item);
+		// console.log('item', item);
 		let isData;
 		if (item.length != 0 && count == 0) {
 			isData = true;
@@ -81,19 +94,32 @@ const AlarmList = props => {
 		} else {
 			isData = false;
 		}
-		return <DailyAlarm index={index} data={item} onLabelClick={item => props.onClickLabel(item)} newNote={newNote} isData={isData} />;
+		return <DailyAlarm index={index} data={item} onLabelClick={item => onLabelClick(item)} newNote={newNote} isData={isData} />;
 	};
-	return (
-		<View style={[styles.container]}>
-			{isEmpty ? (
-				<View>
-					<Text style={[{textAlign: 'center'}]}>소식이 없습니다.</Text>
-				</View>
-			) : (
-				<FlatList data={data} renderItem={renderItem} showsVerticalScrollIndicator={false} />
-			)}
-		</View>
-	);
+	if (loading) {
+		return (
+			<View style={{alignItems: 'center', justifyContent: 'center', flex: 1, backgroundColor: 'white'}}>
+				<ActivityIndicator size={'large'}></ActivityIndicator>
+			</View>
+		);
+	} else {
+		return (
+			<View style={[styles.container]}>
+				{isEmpty ? (
+					<View>
+						<Text style={[{textAlign: 'center'}]}>소식이 없습니다.</Text>
+					</View>
+				) : (
+					<FlatList
+						data={data}
+						renderItem={renderItem}
+						showsVerticalScrollIndicator={false}
+						refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+					/>
+				)}
+			</View>
+		);
+	}
 };
 
 const styles = StyleSheet.create({
@@ -112,7 +138,7 @@ const styles = StyleSheet.create({
 
 AlarmList.defaultProps = {
 	items: [],
-	onClickLabel: e => console.log(e),
+	// onClickLabel: e => console.log(e),
 	onCheckBox: e => console.log(e),
 	checkBoxMode: false, // CheckBox 콘테이너 Show T/F
 	showFollowBtn: false,

--- a/src/component/templete/user/AskQuestion.js
+++ b/src/component/templete/user/AskQuestion.js
@@ -35,7 +35,7 @@ const AskQuestion = ({route}) => {
 		let i;
 		let temp = [];
 		getCommonCodeDynamicQuery(
-			{common_code_c_name: 'helpbycategoryobjects'},
+			{common_code_c_name: 'helpbycategoryobjects', common_code_language: 'kor', common_code_out_type: 'list'},
 
 			result => {
 				// console.log('common code result', result.msg);

--- a/src/component/templete/user/CategoryHelp.js
+++ b/src/component/templete/user/CategoryHelp.js
@@ -12,9 +12,10 @@ const CategoryHelp = ({route, props}) => {
 	const [data, setData] = React.useState();
 	const [loading, setLoading] = React.useState(false);
 	const [categoryList, setCategoryList] = React.useState([]);
-	let categoryName = route.params?.category;
+	const [categoryName, setCategoryName] = React.useState('');
+	// let categoryName = route.params?.category;
 	const [categoryLoad, setCategoryLoaded] = React.useState(false);
-
+	console.log('CategotyName', categoryName);
 	React.useEffect(() => {
 		getHelpByCategoryDynamicQuery(
 			{},
@@ -32,9 +33,9 @@ const CategoryHelp = ({route, props}) => {
 	React.useEffect(() => {
 		// console.log('categoryHelp', route);
 		getCommonCodeDynamicQuery(
-			{common_code_c_name: 'helpbycategoryobjects'},
+			{common_code_c_name: 'helpbycategoryobjects', common_code_language: 'kor', common_code_out_type: 'list'},
 			result => {
-				// console.log('111', result.msg);
+				console.log('111', result.msg);
 				setCategoryList(result.msg.slice(1));
 				setCategoryLoaded(true);
 			},
@@ -43,6 +44,11 @@ const CategoryHelp = ({route, props}) => {
 			},
 		);
 	}, [route]);
+	React.useEffect(() => {
+		setCategoryName(route.params?.category);
+		console.log('category list name', categoryList, categoryName);
+	}, [route.params?.category]);
+
 	React.useEffect(() => {
 		if (categoryName == '전체') {
 			getHelpByCategoryDynamicQuery(
@@ -60,8 +66,8 @@ const CategoryHelp = ({route, props}) => {
 
 		if (categoryLoad) {
 			for (let i in categoryList) {
-				// console.log('list', categoryList[i]);
 				if (categoryList[i].common_code_msg_kor == categoryName && categoryName != '전체') {
+					// console.log("조건 ");
 					getHelpByCategoryDynamicQuery(
 						{help_by_category_common_code_id: categoryList[i]._id},
 						result => {
@@ -75,7 +81,7 @@ const CategoryHelp = ({route, props}) => {
 				}
 			}
 		}
-	}, [categoryList]);
+	}, [categoryName]);
 
 	const renderItem = ({item, index}) => {
 		// console.log('item', item);

--- a/src/navigation/header/InputAndSearchHeader.js
+++ b/src/navigation/header/InputAndSearchHeader.js
@@ -46,6 +46,10 @@ export default InputAndSearchHeader = props => {
 		setSearchInput(text);
 		searchContext.searchInfo.searchInput = text;
 	};
+	const onClear = () => {
+		searchContext.searchInfo.searchInput = '';
+		setSearchInput('');
+	};
 
 	//뒤로 가기 클릭 시 탭이 initialRoute인 Feed로 가던 현상 수정
 	const onPressGoBack = () => {
@@ -68,7 +72,13 @@ export default InputAndSearchHeader = props => {
 				</TouchableOpacity>
 				{searchRoute != 'SearchFeed' ? (
 					<View style={{marginBottom: 20 * DP, flex: 1}}>
-						<InputWithSearchIcon placeholder={'검색어를 입력하세요.'} width={590} onChange={onChangeSearchText} onSearch={confirm} />
+						<InputWithSearchIcon
+							placeholder={'검색어를 입력하세요.'}
+							width={590}
+							onChange={onChangeSearchText}
+							onSearch={confirm}
+							onClear={onClear}
+						/>
 					</View>
 				) : (
 					<></>

--- a/src/navigation/route/RootStackNavigation.js
+++ b/src/navigation/route/RootStackNavigation.js
@@ -68,6 +68,7 @@ import userGlobalObj from 'Root/config/userGlobalObject';
 import CommunityWrite from 'Root/component/templete/community/CommunityWrite';
 import SearchMap from 'Root/component/templete/search/SearchMap';
 import AlarmList from 'Root/component/templete/list/AlarmList';
+import Profile from 'Root/component/templete/profile/Profile';
 const RootStack = createStackNavigator();
 
 export default RootStackNavigation = () => {
@@ -299,6 +300,7 @@ export default RootStackNavigation = () => {
 						</RootStack.Screen>
 						{/* <RootStack.Screen name="SearchMap" component={SearchMap} options={{header: props => <SimpleHeader {...props} />, title: '주소 설정'}} /> */}
 						<RootStack.Screen name="AlarmList" component={AlarmList} options={{header: props => <SimpleHeader {...props} />, title: '소식'}} />
+						<RootStack.Screen name="Profile" component={Profile} options={{header: props => <SimpleHeader {...props} />, title: '소식'}} />
 					</RootStack.Navigator>
 				</NavigationContainer>
 

--- a/src/navigation/route/main_tab/my_stack/CategoryHelpTopTabNavigation.js
+++ b/src/navigation/route/main_tab/my_stack/CategoryHelpTopTabNavigation.js
@@ -23,11 +23,12 @@ const CategoryHelpTopTabNavigation = ({route, navigation}) => {
 	const [searchText, setSearchText] = React.useState('');
 	const [data, setData] = React.useState();
 	const [commonData, setCommomData] = React.useState();
+
 	React.useEffect(() => {
 		let temp = [];
 		let temp2 = {};
 		getCommonCodeDynamicQuery(
-			{common_code_c_name: 'helpbycategoryobjects'},
+			{common_code_c_name: 'helpbycategoryobjects', common_code_language: 'kor', common_code_out_type: 'list'},
 			result => {
 				console.log('result', result);
 				for (let i in result.msg) {
@@ -80,7 +81,6 @@ const CategoryHelpTopTabNavigation = ({route, navigation}) => {
 	const onPressAsk = () => {
 		navigation.push('ServiceTab');
 	};
-
 	if (loading) {
 		return (
 			<View style={{alignItems: 'center', justifyContent: 'center', flex: 1, backgroundColor: 'white'}}>


### PR DESCRIPTION
*수정 사항: 알람 기능 보완 
*수정 결과: 알람 swipe to refresh 기능도입했습니다. 그리고 팔로우 알림 클릭시 팔로우한 사람 프로필로 이동하는 기능을 만들었는데 navigation.push를 사용하지만 프로필에서 뒤로가기를 하면 메인 피드로 가는 상황입니다. 
댓글 알람에 대해서 어떤식으로 이동할지 논의가 필요합니다. 

그리고 알람 flatlist의 가변 height이 잘 적용이 안되고있습니다. 

*수정 파일: 
수정
CategoryHelpTopTabNavigation - api 수정
RootStackNavigation - 알림클릭시 navigation push 용 stack 추가
InputAndSearchHeader - onClear시 serachContext삭제 추가
CategoryHelp - api 변한거 처리 
AskQuestion - api 수정
AlarmList - async storage 로 알람목록 비교후 달라졌으면 위에 배경색 바꾸는 기능/ swipe to refresh 기능 추가
OneAlarm- 팔로워 알람시 프로필로 이동 기능 추가
DailyAlarm - flatlist item 가변 height 적용 실패 
