### PR TITLE
[재현] 소식 팔로워 navigation 수정, 소식 가변 height 적용, 프로필 쪽지 보내기 기능

### DIFF
--- a/src/component/organism/list/DailyAlarm.js
+++ b/src/component/organism/list/DailyAlarm.js
@@ -23,9 +23,9 @@ const DailyAlarm = props => {
 	const renderItem = ({item, index}) => {
 		// console.log('item', item);
 		return (
-			<View style={[accountHashList.userAccount]}>
-				<OneAlarm data={item} onLabelClick={item => props.onLabelClick(item)} newNote={props.newNote} index={index} isData={props.isData} />
-			</View>
+			// <View style={[accountHashList.userAccount]}>
+			<OneAlarm data={item} onLabelClick={item => props.onLabelClick(item)} newNote={props.newNote} index={index} isData={props.isData} />
+			// </View>
 		);
 	};
 	if (props.data.length == 0) {
@@ -75,4 +75,4 @@ DailyAlarm.defaultProps = {
 	showFollowBtn: false,
 };
 
-export default DailyAlarm;
+export default React.memo(DailyAlarm);

--- a/src/component/organism/list/NoteMessageList.js
+++ b/src/component/organism/list/NoteMessageList.js
@@ -42,10 +42,12 @@ const NoteMessageList = props => {
 const styles = StyleSheet.create({
 	container: {
 		width: 750 * DP,
+		height: 1150 * DP,
 	},
 	messageItemContainer: {
 		width: 750 * DP,
 		marginBottom: 30 * DP,
+		// minHeight: 1150 * DP,
 	},
 });
 

--- a/src/component/organism/listitem/OneMessage.js
+++ b/src/component/organism/listitem/OneMessage.js
@@ -10,7 +10,7 @@ import {APRI10, GRAY10, GRAY20, GRAY30, TEXTBASECOLOR, WHITE} from 'Root/config/
 import {ProfileDefaultImg} from 'Component/atom/icon';
 import {getTimeLapsed} from 'Root/util/dateutil';
 const OneMessage = props => {
-	console.log('NoteMessageList props', props.data);
+	// console.log('NoteMessageList props', props.data);
 	const data = props.data;
 	//사용자가 보낸메세지 일때
 	if (userGlobalObject.userInfo._id == data.memobox_send_id._id) {

--- a/src/component/organism/listitem/UserNote.js
+++ b/src/component/organism/listitem/UserNote.js
@@ -19,9 +19,9 @@ import {ProfileDefaultImg} from 'Root/component/atom/icon';
 const UserNote = props => {
 	// console.log('UserAccount item', props.data);
 	const data = props.data;
-	console.log('time', data.memobox_date);
-	console.log('getTime', getTimeLapsed(data.memobox_date));
-	console.log('UserNote props', data);
+	// console.log('time', data.memobox_date);
+	// console.log('getTime', getTimeLapsed(data.memobox_date));
+	// console.log('UserNote props', data);
 
 	return (
 		<View style={[styles.userNoteContainer]}>

--- a/src/component/templete/list/AlarmList.js
+++ b/src/component/templete/list/AlarmList.js
@@ -67,14 +67,14 @@ const AlarmList = props => {
 		);
 	};
 	const onLabelClick = data => {
-		console.log(data.notice_user_collection, data, 'zz');
+		console.log(data.target_object_type, data, 'zz');
 		let navState = props.navigation.getState();
 		console.log('navState', navState);
 
-		switch (data.notice_user_collection) {
+		switch (data.target_object_type) {
 			case 'comment':
 				break;
-			case 'follow':
+			case 'FollowObject':
 				getUserProfile(
 					{userobject_id: data.notice_user_related_id._id},
 					result => {

--- a/src/component/templete/list/AlarmList.js
+++ b/src/component/templete/list/AlarmList.js
@@ -11,7 +11,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {temp_inputLongText} from 'Root/i18n/msg';
 import {lo} from '../style_address';
 import {getUserProfile} from 'Root/api/userapi';
-
+import {CommonActions, useNavigationState} from '@react-navigation/native';
+import {useNavigation} from '@react-navigation/native';
 const wait = timeout => {
 	return new Promise(resolve => setTimeout(resolve, timeout));
 };
@@ -22,8 +23,10 @@ const AlarmList = props => {
 	const [data, setData] = React.useState();
 	const [isEmpty, setIsEmpty] = React.useState();
 	const [loading, setLoading] = React.useState(true);
+	const navigation = useNavigation();
 	let count = 0;
 	const [refreshing, setRefreshing] = React.useState(false);
+	const navState = useNavigationState(state => state);
 	console.log('props', props);
 	const onRefresh = React.useCallback(() => {
 		setRefreshing(true);
@@ -65,6 +68,9 @@ const AlarmList = props => {
 	};
 	const onLabelClick = data => {
 		console.log(data.notice_user_collection, data, 'zz');
+		let navState = props.navigation.getState();
+		console.log('navState', navState);
+
 		switch (data.notice_user_collection) {
 			case 'comment':
 				break;
@@ -73,14 +79,18 @@ const AlarmList = props => {
 					{userobject_id: data.notice_user_related_id._id},
 					result => {
 						console.log('result', result.msg);
-						props.navigation.navigate('UserProfile', {userobject: result.msg});
+						navigation.dispatch({
+							...CommonActions.reset({
+								index: 1,
+								routes: [{name: 'MainTab'}, {name: 'AlarmList'}, {name: 'Profile', params: {userobject: result.msg}}],
+							}),
+						});
 					},
 					err => {
 						console.log('err', err);
 					},
 				);
-				// navigation.navigate('UserProfile', {userobject: data.notice_user_related_id});
-				// props.navigation.push('UserProfile', {userobject: data.notice_user_related_id});
+
 				break;
 		}
 	};
@@ -94,7 +104,7 @@ const AlarmList = props => {
 		} else {
 			isData = false;
 		}
-		return <DailyAlarm index={index} data={item} onLabelClick={item => onLabelClick(item)} newNote={newNote} isData={isData} />;
+		return <DailyAlarm index={index} data={item} onLabelClick={onLabelClick} newNote={newNote} isData={isData} />;
 	};
 	if (loading) {
 		return (
@@ -144,4 +154,4 @@ AlarmList.defaultProps = {
 	showFollowBtn: false,
 };
 
-export default AlarmList;
+export default React.memo(AlarmList);

--- a/src/component/templete/list/AlarmList.js
+++ b/src/component/templete/list/AlarmList.js
@@ -67,9 +67,9 @@ const AlarmList = props => {
 		);
 	};
 	const onLabelClick = data => {
-		console.log(data.target_object_type, data, 'zz');
+		console.log(data.target_object_type, data);
 		let navState = props.navigation.getState();
-		console.log('navState', navState);
+		// console.log('navState', navState);
 
 		switch (data.target_object_type) {
 			case 'comment':
@@ -91,6 +91,31 @@ const AlarmList = props => {
 					},
 				);
 
+				break;
+			case 'MemoBoxObject':
+				navigation.dispatch({
+					...CommonActions.reset({
+						index: 0,
+						routes: [
+							{name: 'MainTab'},
+							{name: 'AlarmList'},
+							{name: 'UserNotePage', params: {title: data.notice_user_related_id.user_nickname, _id: data.notice_user_related_id._id}},
+						],
+					}),
+				});
+				break;
+			case 'FeedObject':
+				if (data.notice_object_type == 'LikeFeedObject') {
+					const selected = {_id: data.target_object};
+					getUserProfile({userobject_id: data.notice_user_receive_id}, result => {
+						navigation.dispatch({
+							...CommonActions.reset({
+								index: 1,
+								routes: [{name: 'MainTab'}, {name: 'AlarmList'}, {name: 'UserFeedList', params: {userobject: result.msg, selected: selected}}],
+							}),
+						});
+					});
+				}
 				break;
 		}
 	};

--- a/src/component/templete/profile/Profile.js
+++ b/src/component/templete/profile/Profile.js
@@ -100,6 +100,7 @@ export default Profile = ({route}) => {
 	//프로필의 피드탭의 피드 썸네일 클릭
 	const onClick_Thumbnail_FeedTab = (index, item) => {
 		navigation.push('UserFeedList', {userobject: data, selected: item});
+		console.log('data and item', data, item);
 	};
 
 	//프로필의 태그탭의 피드 썸네일 클릭

--- a/src/component/templete/profile/Profile.js
+++ b/src/component/templete/profile/Profile.js
@@ -20,6 +20,7 @@ import DP from 'Root/config/dp';
 import {getFeedListByUserId, getUserTaggedFeedList} from 'Root/api/feedapi';
 import {useNavigation} from '@react-navigation/core';
 import Loading from 'Root/component/molecules/modal/Loading';
+import {createMemoBox} from 'Root/api/userapi';
 
 export default Profile = ({route}) => {
 	const navigation = useNavigation();
@@ -29,7 +30,7 @@ export default Profile = ({route}) => {
 	const [showOwnerState, setShowOwnerState] = React.useState(false); // 현재 로드되어 있는 profile의 userType이 Pet인 경우 반려인 계정 리스트의 출력 여부
 	const [showCompanion, setShowCompanion] = React.useState(false); // User계정이 반려동물버튼을 클릭
 	// console.log('tabMenuselc', tabMenuSelected);
-
+	console.log('data', data, userGlobalObject);
 	const fetchData = async () => {
 		if (route.params && route.params.userobject) {
 			getUserProfile(
@@ -156,8 +157,28 @@ export default Profile = ({route}) => {
 		navigation.push('UserProfile', {userobject: item});
 	};
 
-	const onPressSendMsg = () => {
-		alert('sendMsg');
+	const onPressSendMsg = (_id, name) => {
+		// alert('sendMsg');
+		setTimeout(() => {
+			Modal.popMessageModal(
+				name,
+				msg => {
+					createMemoBox(
+						{memobox_receive_id: _id, memobox_contents: msg},
+						result => {
+							console.log('message sent success', result);
+							Modal.popOneBtn('쪽지 전송하였습니다.', '확인', () => Modal.close());
+						},
+						err => {
+							console.log('message sent err', err);
+						},
+					);
+					console.log('msg', msg);
+					Modal.close();
+				},
+				() => alert('나가기'),
+			);
+		}, 100);
 	};
 
 	//보호 동물 추가
@@ -377,27 +398,68 @@ export default Profile = ({route}) => {
 			<TabSelectFilled_Type2 items={['피드', '태그', '커뮤니티']} onSelect={onSelectTabMenu} />
 		);
 	};
-
-	return (
-		<View style={[login_style.wrp_main, profile.container]}>
-			{data != '' ? (
-				<>
-					{showTabContent()}
-					{userGlobalObject.userInfo && (
-						<View style={[{width: 94 * DP}, {height: 94 * DP}, profile.floatingBtn, {alignItems: 'center'}, {justifyContent: 'center'}]}>
-							{data.user_type == 'pet' ? <Message94 onPress={onPressSendMsg} /> : <Write94 onPress={moveToFeedWrite} />}
+	if (data.user_type == 'pet') {
+		return (
+			<View style={[login_style.wrp_main, profile.container]}>
+				{data != '' ? (
+					<>
+						{showTabContent()}
+						<View
+							style={[
+								temp_style.floatingBtn,
+								profile.floatingBtn,
+								{alignItems: 'center'},
+								{justifyContent: 'center'},
+								// {backgroundColor: 'yellow'},
+							]}>
+							<Write94 onPress={moveToFeedWrite} />
 						</View>
-						// <View style={[temp_style.floatingBtn, profile.floatingBtn, {alignItems: 'center'}, {justifyContent: 'center'}, {backgroundColor: 'yellow'}]}>
-						// 	{data.user_type == 'pet' ? <Message94 onPress={onPressSendMsg} /> : <Write94 onPress={moveToFeedWrite} />}
-						// </View>
-					)}
-				</>
-			) : (
-				<>
-					<Loading isModal={false} />
-				</>
-			)}
-		</View>
-	);
+					</>
+				) : (
+					<>
+						<Loading isModal={false} />
+					</>
+				)}
+			</View>
+		);
+	} else {
+		return (
+			<View style={[login_style.wrp_main, profile.container]}>
+				{data != '' ? (
+					<>
+						{showTabContent()}
+						{userGlobalObject.userInfo._id == data._id ? (
+							<View
+								style={[
+									temp_style.floatingBtn,
+									profile.floatingBtn,
+									{alignItems: 'center'},
+									{justifyContent: 'center'},
+									// {backgroundColor: 'yellow'},
+								]}>
+								<Write94 onPress={moveToFeedWrite} />
+							</View>
+						) : (
+							<View
+								style={[
+									temp_style.floatingTwoBtn,
+									profile.floatingBtn,
+									{alignItems: 'center'},
+									{justifyContent: 'center'},
+									// {backgroundColor: 'yellow'},
+								]}>
+								<Message94 onPress={() => onPressSendMsg(data._id, data.user_nickname)} />
+								<Write94 onPress={moveToFeedWrite} />
+							</View>
+						)}
+					</>
+				) : (
+					<>
+						<Loading isModal={false} />
+					</>
+				)}
+			</View>
+		);
+	}
 };
 //PR충돌로 인한 해결

--- a/src/component/templete/style_templete.js
+++ b/src/component/templete/style_templete.js
@@ -531,6 +531,12 @@ export const temp_style = StyleSheet.create({
 		width: 110 * DP,
 		height: 110 * DP,
 	},
+	floatingTwoBtn: {
+		flexDirection: 'column',
+
+		width: 110 * DP,
+		height: 220 * DP,
+	},
 	editComment: {},
 	aidRequest: {
 		// width: 654 * DP,

--- a/src/component/templete/user/ReceivedMessage.js
+++ b/src/component/templete/user/ReceivedMessage.js
@@ -111,7 +111,7 @@ export default ReceivedMessage = ({route}) => {
 		let copy = [...data];
 		copy[index].checkBoxState = !copy[index].checkBoxState;
 	};
-	if (data.length == 0) {
+	if (data?.length == 0) {
 		return (
 			<View style={[login_style.wrp_main, {flex: 1}]}>
 				<Text>쪽지 내역이 없습니다.</Text>

--- a/src/component/templete/user/ReceivedMessage.js
+++ b/src/component/templete/user/ReceivedMessage.js
@@ -86,9 +86,9 @@ export default ReceivedMessage = ({route}) => {
 	const deleteSelectedItem = () => {
 		let copy = [...data];
 		copy = copy.filter(e => e.checkBoxState == true);
-		console.log('filtered copy', copy);
+		// console.log('filtered copy', copy);
 		copy.map((v, i) => {
-			console.log('vvv', v);
+			// console.log('vvv', v);
 			deleteMemoBoxWithUserObjectID(
 				{user_object_id: v.opponent},
 				result => {
@@ -129,7 +129,7 @@ export default ReceivedMessage = ({route}) => {
 						received={received}
 					/>
 				</View>
-				<View style={[styles.noteList, {height: null}]}>
+				<View style={[styles.noteList]}>
 					<NoteList data={data} checkBoxMode={checkBoxMode} onClickLabel={onClickLabel} onCheckBox={onCheckBox} routeName={route.name} />
 				</View>
 				{/* <View style={[styles.messageBtnContainer]}>

--- a/src/component/templete/user/SettingAlarm.js
+++ b/src/component/templete/user/SettingAlarm.js
@@ -14,6 +14,7 @@ import {
 	MY_APPLY_STATUS_CHANGE_ALRAM,
 	MY_POST_ALRAM,
 	MY_POST_COMMENT_ALRAM,
+	NEW_FOLLOWER,
 	PET_VACCIN_DATE_ALRAM,
 	TAG_OR_FOLLOW_ALRAM,
 } from 'Root/i18n/msg';
@@ -143,25 +144,21 @@ export default SettingAlarm = ({route}) => {
 					</View>
 					<View style={styles.serviceAlarmContainer}>
 						<Text style={[txt.noto32b, {color: GRAY10}]}>서비스별 알림</Text>
-						<View style={[styles.alarmDetailEachContainer, {marginTop: 30 * DP}]}>
+						{/* <View style={[styles.alarmDetailEachContainer, {marginTop: 30 * DP}]}>
 							<OneLineOnOff data={alarm} name={FOLLWER_NEW_POST_ALRAM} keys="notice_newfollower" switchButton={switchButton} />
-						</View>
-						<View style={[styles.alarmDetailEachContainer, {marginTop: 24 * DP}]}>
-							<OneLineOnOff
-								data={alarm}
-								name={FAVORITE_PROTECT_STATUS_CHANGE_ALRAM}
-								keys="notice_favorite_protect_request"
-								switchButton={switchButton}
-							/>
-						</View>
+						</View> */}
+
 						<View style={[styles.alarmDetailEachContainer, {marginTop: 24 * DP}]}>
 							<OneLineOnOff data={alarm} name={PET_VACCIN_DATE_ALRAM} keys="notice_pet_vaccination" switchButton={switchButton} />
+						</View>
+						<View style={[styles.alarmDetailEachContainer, {marginTop: 24 * DP}]}>
+							<OneLineOnOff data={alarm} name={'쪽지 수신 알림'} keys="notice_favorite_protect_request" switchButton={switchButton} />
 						</View>
 					</View>
 					<View style={styles.activityAlarmContainer}>
 						<Text style={[txt.noto32b, {color: GRAY10}]}>내 활동 알림</Text>
 						<View style={[styles.alarmDetailEachContainer, {marginTop: 30 * DP}]}>
-							<OneLineOnOff data={alarm} name={MY_POST_ALRAM} keys="notice_my_post" switchButton={switchButton} />
+							<OneLineOnOff data={alarm} name={NEW_FOLLOWER} keys="notice_newfollower" switchButton={switchButton} />
 						</View>
 						<View style={[styles.alarmDetailEachContainer, {marginTop: 24 * DP}]}>
 							<OneLineOnOff data={alarm} name={MY_POST_COMMENT_ALRAM} keys="notice_comment_on_my_post" switchButton={switchButton} />
@@ -195,7 +192,7 @@ export default SettingAlarm = ({route}) => {
 const styles = StyleSheet.create({
 	container: {
 		width: 750 * DP,
-		height: 1006 * DP,
+		height: 938 * DP,
 		marginTop: 10 * DP,
 		backgroundColor: '#FFFFFF',
 	},
@@ -207,7 +204,7 @@ const styles = StyleSheet.create({
 		justifyContent: 'center',
 	},
 	serviceAlarmContainer: {
-		height: 338 * DP,
+		height: 270 * DP,
 		paddingLeft: 48 * DP,
 		borderBottomColor: GRAY40,
 		borderBottomWidth: 2 * DP,

--- a/src/component/templete/user/SettingAlarm.js
+++ b/src/component/templete/user/SettingAlarm.js
@@ -158,13 +158,13 @@ export default SettingAlarm = ({route}) => {
 					<View style={styles.activityAlarmContainer}>
 						<Text style={[txt.noto32b, {color: GRAY10}]}>내 활동 알림</Text>
 						<View style={[styles.alarmDetailEachContainer, {marginTop: 30 * DP}]}>
-							<OneLineOnOff data={alarm} name={NEW_FOLLOWER} keys="notice_newfollower" switchButton={switchButton} />
+							<OneLineOnOff data={alarm} name={NEW_FOLLOWER} keys="notice_follow" switchButton={switchButton} />
 						</View>
 						<View style={[styles.alarmDetailEachContainer, {marginTop: 24 * DP}]}>
-							<OneLineOnOff data={alarm} name={MY_POST_COMMENT_ALRAM} keys="notice_comment_on_my_post" switchButton={switchButton} />
+							<OneLineOnOff data={alarm} name={MY_POST_COMMENT_ALRAM} keys="notice_my_post" switchButton={switchButton} />
 						</View>
 						<View style={[styles.alarmDetailEachContainer, {marginTop: 24 * DP}]}>
-							<OneLineOnOff data={alarm} name={TAG_OR_FOLLOW_ALRAM} keys="notice_tag_follower" switchButton={switchButton} />
+							<OneLineOnOff data={alarm} name={TAG_OR_FOLLOW_ALRAM} keys="notice_tag" switchButton={switchButton} />
 						</View>
 						<View style={[styles.alarmDetailEachContainer, {marginTop: 24 * DP}]}>
 							<OneLineOnOff data={alarm} name={MY_APPLY_STATUS_CHANGE_ALRAM} keys="notice_my_applicant" switchButton={switchButton} />

--- a/src/component/templete/user/UserNotePage.js
+++ b/src/component/templete/user/UserNotePage.js
@@ -24,7 +24,7 @@ import {createMemoBox} from 'Root/api/userapi';
  * @param {boolean} props.checkBoxState - 선택 여부 (default = false)
  */
 const UserNotePage = ({route}) => {
-	console.log('userNotePage', route.params);
+	// console.log('userNotePage', route.params);
 	const keyboardY = useKeyboardBottom(0 * DP);
 	const navigation = useNavigation();
 	const [data, setData] = React.useState();
@@ -32,7 +32,7 @@ const UserNotePage = ({route}) => {
 	const input = React.useRef();
 	const [content, setContent] = React.useState('');
 	const [sent, setSent] = React.useState(false);
-	console.log('data', data);
+	// console.log('data', data);
 
 	React.useLayoutEffect(() => {
 		navigation.setOptions({tabBarVisible: false});
@@ -99,6 +99,7 @@ const styles = StyleSheet.create({
 	messageContainer: {
 		marginTop: 30 * DP,
 		height: 1150 * DP,
+		// backgroundColor: 'yellow',
 	},
 });
 

--- a/src/i18n/msg.js
+++ b/src/i18n/msg.js
@@ -473,9 +473,10 @@ export const FOLLWER_NEW_POST_ALRAM = '팔로워 새 게시글 알림';
 export const FAVORITE_PROTECT_STATUS_CHANGE_ALRAM = '즐겨찾은 보호요청 상태 변경 알림';
 export const PET_VACCIN_DATE_ALRAM = '반려동물의 접종 예정일 알림';
 export const MY_POST_ALRAM = '내 게시글 알림';
-export const MY_POST_COMMENT_ALRAM = '내 게시글에 달린 댓글 알림';
-export const TAG_OR_FOLLOW_ALRAM = '나를 태그하거나 팔로우시 알림';
-export const MY_APPLY_STATUS_CHANGE_ALRAM = '내 신청서 상태 변경시 알림';
+export const MY_POST_COMMENT_ALRAM = '내가 쓴 글/댓글 업데이트 알림';
+export const TAG_OR_FOLLOW_ALRAM = '나를 태그할 시 알림';
+export const MY_APPLY_STATUS_CHANGE_ALRAM = '내 신청 상태 변경 알림';
+export const NEW_FOLLOWER = '나를 팔로우 시 알림';
 
 export const INITIAL_NUMBER = ['010', '02', '031', '033', '043', '041', '054', '055', '063', '061', '064'];
 

--- a/src/navigation/route/RootStackNavigation.js
+++ b/src/navigation/route/RootStackNavigation.js
@@ -300,7 +300,11 @@ export default RootStackNavigation = () => {
 						</RootStack.Screen>
 						{/* <RootStack.Screen name="SearchMap" component={SearchMap} options={{header: props => <SimpleHeader {...props} />, title: '주소 설정'}} /> */}
 						<RootStack.Screen name="AlarmList" component={AlarmList} options={{header: props => <SimpleHeader {...props} />, title: '소식'}} />
-						<RootStack.Screen name="Profile" component={Profile} options={{header: props => <SimpleHeader {...props} />, title: '소식'}} />
+						<RootStack.Screen
+							name="Profile"
+							component={Profile}
+							options={{header: props => <MeatBallHeader {...props} menu={['신고하기', '신고']} />, title: '프로필'}}
+						/>
 					</RootStack.Navigator>
 				</NavigationContainer>
 

--- a/src/navigation/route/RootStackNavigation.js
+++ b/src/navigation/route/RootStackNavigation.js
@@ -40,7 +40,6 @@ import SearchTabNavigation from './search_tab/SearchTabNavigation';
 import AccountPicker from 'Templete/search/AccountPicker';
 
 import {PIC_SELECTION} from 'Root/i18n/msg';
-import FeedList from 'Templete/feed/FeedListForHashTag';
 
 import SimpleHeader from 'Navigation/header/SimpleHeader';
 import SendHeader from '../header/SendHeader';
@@ -67,8 +66,11 @@ import {userLogin} from 'Root/api/userapi';
 import userGlobalObj from 'Root/config/userGlobalObject';
 import CommunityWrite from 'Root/component/templete/community/CommunityWrite';
 import SearchMap from 'Root/component/templete/search/SearchMap';
-import AlarmList from 'Root/component/templete/list/AlarmList';
-import Profile from 'Root/component/templete/profile/Profile';
+import AlarmList from 'Templete/list/AlarmList';
+import Profile from 'Templete/profile/Profile';
+import UserNotePage from 'Templete/user/UserNotePage';
+import FeedList from 'Templete/feed/FeedList';
+import Feed from 'Root/component/organism/feed/Feed';
 const RootStack = createStackNavigator();
 
 export default RootStackNavigation = () => {
@@ -305,6 +307,8 @@ export default RootStackNavigation = () => {
 							component={Profile}
 							options={{header: props => <MeatBallHeader {...props} menu={['신고하기', '신고']} />, title: '프로필'}}
 						/>
+						<RootStack.Screen name="UserNotePage" component={UserNotePage} options={{header: props => <SimpleHeader {...props} />}} />
+						<RootStack.Screen name="UserFeedList" component={FeedList} options={{header: props => <SimpleHeader {...props} />}} />
 					</RootStack.Navigator>
 				</NavigationContainer>
 


### PR DESCRIPTION
*수정 사항: 소식 팔로워 navigation기능, 소식 가변 height 적용, 프로필 쪽지 보내기 기능
*수정 결과: navigation을 reset하여 구현하였습니다. 
소식 가변 height 적용되었고 flatlist 컴포넌트를 React.memo를 적용하였습니다. 
프로필별(본인, 다른사람의 계정, 반려동물계정) 분기처리를 하여 쪽지 보내기 기능을 적용하였습니다.
현재 profile.js 파일에서 상우님도 작업을해서 충돌이 일어날것으로 예상됩니다.
*수정 파일: 
수정
DailyAlarm - 가변 height 적용
AlarmList - navigation 수정
ReceivedMessage
msg.js - 문자열 수정
RootStackNavigation.js - 프로필 스택 추가
SettingAlarm - 알림 항목 수정 적용
style_templete - 스타일 추가 
Profile - 사용자 프로필 별로 쪽지 기능 추가

