### PR TITLE
[재현] 알람, 봉사활동 보호, 입양 이동. 세부 화면 논의필요

### DIFF
--- a/src/component/organism/feed/FeedContent.js
+++ b/src/component/organism/feed/FeedContent.js
@@ -72,7 +72,6 @@ export default FeedContent = props => {
 	const [labelLayout, setlabelLayout] = React.useState({height: 0, width: 0});
 	const [show, setShow] = React.useState(false);
 	const [send, setSend] = React.useState();
-	console.log('35353', feed_avatar_id, 'sss', feed_writer_id);
 	//코드 중복 해소를 위한 처리.
 	const feed_writer = props.data.feed_avatar_id ? props.data.feed_avatar_id : props.data.feed_writer_id;
 	React.useEffect(() => {

--- a/src/component/templete/list/AlarmList.js
+++ b/src/component/templete/list/AlarmList.js
@@ -14,6 +14,9 @@ import {getUserProfile} from 'Root/api/userapi';
 import {CommonActions, useNavigationState} from '@react-navigation/native';
 import {useNavigation} from '@react-navigation/native';
 import {getFeedDetailById} from 'Root/api/feedapi';
+import {getUserVolunteerActivityList, getVolunteerActivityById} from 'Root/api/volunteerapi';
+import {getApplyDetailById} from 'Root/api/protectapi';
+import {getAppliesRecord} from 'Root/api/protectapi';
 const wait = timeout => {
 	return new Promise(resolve => setTimeout(resolve, timeout));
 };
@@ -151,6 +154,31 @@ const AlarmList = props => {
 						}),
 					);
 				});
+				break;
+			case 'VolunteerActivityApplicantObject':
+				getUserVolunteerActivityList({}, result => {
+					console.log('result', result.msg);
+					let result_msg = result.msg;
+
+					for (let i of result_msg) {
+						if (i._id == data.target_object) {
+							navigation.push('ShelterVolunteerForm', i);
+						}
+					}
+				});
+				break;
+			case 'ProtectionActivityApplicantObject':
+				// getAppliesRecord
+				getApplyDetailById({protect_act_object_id: data.target_object}, result => {
+					let result_msg = result.msg;
+					result_msg.shelter_name = result.msg.protect_act_request_shelter_id.shelter_name;
+					result_msg.protect_request_date = result.msg.protect_act_request_article_id.protect_request_date;
+					result_msg.protect_animal_rescue_location = result.msg.protect_act_request_article_id.protect_animal_id.protect_animal_rescue_location;
+					result.msg.protect_request_photos_uri = result.msg.protect_act_request_article_id.protect_request_photos_uri;
+					console.log('result', result_msg);
+					navigation.push('ApplyAdoptionDetails', result_msg);
+				});
+
 				break;
 		}
 	};

--- a/src/component/templete/protection/ApplyAdoptionList.js
+++ b/src/component/templete/protection/ApplyAdoptionList.js
@@ -17,6 +17,7 @@ export default ApplyAdoptionList = props => {
 	};
 	const onLabelClick = item => {
 		// console.log('onLabelClick !!');
+		console.log('itme data', item);
 		navigation.push('ApplyAdoptionDetails', item);
 	};
 

--- a/src/navigation/route/RootStackNavigation.js
+++ b/src/navigation/route/RootStackNavigation.js
@@ -312,6 +312,16 @@ export default RootStackNavigation = () => {
 						<RootStack.Screen name="UserNotePage" component={UserNotePage} options={{header: props => <SimpleHeader {...props} />}} />
 						<RootStack.Screen name="UserFeedList" component={FeedList} options={{header: props => <SimpleHeader {...props} />}} />
 						<RootStack.Screen name="FeedCommentList" component={FeedCommentList} options={{header: props => <AlarmAndSearchHeader {...props} />}} />
+						<RootStack.Screen
+							name="ShelterVolunteerForm"
+							component={ApplicationFormVolunteer}
+							options={{header: props => <SimpleHeader {...props} />, title: '봉사활동 신청서'}}
+						/>
+						<RootStack.Screen
+							name="ApplyAdoptionDetails"
+							component={ApplyDetails}
+							options={{header: props => <SimpleHeader {...props} />, title: '입양 신청 내역'}}
+						/>
 					</RootStack.Navigator>
 				</NavigationContainer>
 


### PR DESCRIPTION
*수정 사항:AlarmList에서 봉사활동, 보호, 입양의 화면이동을 구현했습니다.
*수정 결과: 현재 이동은 잘되나 헤더의 title분기 처리가 제대로 안되어 전부 입양신청으로 보이고있습니다. 또한 입양,보호 상태변경 알람에 대한 화면이 적절한지 회의해야할 것 같습니다.
*수정 파일:
AlarmList
RootStackNavigatiln
