### PR TITLE
[하늘] ios permission / camera roll 모듈 코드 추가

### DIFF
--- a/IosModuleTest_App.js
+++ b/IosModuleTest_App.js
@@ -1,0 +1,205 @@
+import React, { Component } from 'react';
+import { Alert, Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import CameraRoll from './src/module/CameraRollIos';
+import PermissionIos from './src/module/PermissionIos';
+import { PERMISSION_IOS_STATUS, PERMISSION_IOS_TYPES } from './src/module/PermissionIosStatics';
+
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  button: {
+    backgroundColor: 'blue',
+    marginBottom: 10,
+  },
+  text: {
+    color: 'white',
+    fontSize: 20,
+    textAlign: 'center',
+  },
+});
+
+
+export default class App extends Component {
+  constructor() {
+    super();
+    this.state = {
+      image: null,
+      images: null,
+    };
+  }
+
+  //이런 식으로 쪼개서 퍼미션을 체크해도 되고
+  //PermissionIos.updatePermission(); 을 그대로 불러서 써도 된다
+  checkPermission(isCustomized = false){
+    if(isCustomized) {
+      PermissionIos.checkPermission()
+      .then(r => {
+        console.log('check permission: %s', r);
+        if( r == "notDetermined"){
+          PermissionIos.openSetting();
+        }
+        else if (r != "authorized"){
+          PermissionIos.requestPermission();
+        }
+      })
+      .catch(err => {
+        console.log(err);
+      });
+    } else {
+      PermissionIos.updatePermission();
+    }
+  };
+
+  save(){
+    if(this.state.image == null){
+      console.log('image is null');
+      return;
+    }
+
+    CameraRoll.saveImage(this.state.image.uri)
+    .catch(err => {
+      console.log(err);
+    });
+  }
+
+  
+  compress(){
+    if(this.state.image == null){
+      console.log('image is null');
+      return;
+    }
+
+    CameraRoll.compressImage(this.state.image.uri, 160, 240, 0.5)
+    .then(r => {
+      console.log(r);
+      this.setState({
+        image: {
+          uri: r,
+          width: 10,
+          height: 500,
+        },
+        images: null,
+      });
+    })
+    .catch(err => {
+      console.log(err);
+    })
+  }
+
+  //cameraroll에서 이미지 불러오는 건 공식페이지 샘플과 동일, 다만 smart album이 추가되어 있음.
+  //관련하여 안내 작성 예정
+  //이 함수는 전체앨범에서 0번째 인덱스의 이미지를 가져옴
+  getImage(){
+    CameraRoll.getPhotos({
+      first: 3,
+      toTime: 0,
+      assetType: 'Photos',
+      include: ['imageSize', 'filename', 'filesize'],
+      groupTypes: 'All',
+    })
+      .then(r => {
+        this.setState({
+              image: {
+                uri: r.edges[0].node.image.uri,
+                width: r.edges[0].node.image.width,
+                height: r.edges[0].node.image.height,
+              },
+              images: null,
+            });
+      })
+      .catch(err => {
+        console.log(err);
+      });
+  }
+
+  cleanupImages() {
+    CameraRoll.clean()
+      .then(() => {
+        console.log('removed tmp images from tmp directory');
+      })
+      .catch((e) => {
+        alert(e);
+      });
+  }
+
+  scaledHeight(oldW, oldH, newW) {
+    return (oldH / oldW) * newW;
+  }
+
+  renderImage(image) {
+    return (
+      <Image
+        style={{ width: 300, height: 300, resizeMode: 'contain' }}
+        source={image}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <ScrollView>
+          {this.state.image ? this.renderImage(this.state.image) : null}
+          {this.state.images
+            ? this.state.images.map((i) => (
+                <View key={i.uri}>{this.renderImage(i)}</View>
+              ))
+            : null}
+        </ScrollView>
+
+        <TouchableOpacity
+          onPress={() => this.checkPermission(false)}
+          style={styles.button}>
+          <Text style={styles.text}>Ask permission / Check Permission</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => this.getImage()}
+          style={styles.button}>
+          <Text style={styles.text}>getImage</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => {
+            console.log("image uri::::");
+            console.log(this.state.image.uri);
+          }}
+          style={styles.button}>
+          <Text style={styles.text}>console log uri</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => {
+            CameraRoll.saveImage(this.state.image.uri)
+            .catch(err => {
+              console.log(err);
+            });
+          }}
+          style={styles.button}>
+          <Text style={styles.text}>save selected Image</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => {
+            test++;
+            console.log(test);
+            this.compress();
+          }}
+          style={styles.button}>
+          <Text style={styles.text}>compress selected Image</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => this.cleanupImages()}
+          style={styles.button}>
+          <Text style={styles.text}>clean temp images</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+}

--- a/ios/anilog.xcodeproj/project.pbxproj
+++ b/ios/anilog.xcodeproj/project.pbxproj
@@ -25,6 +25,9 @@
 		A6656D5242D64B84A760D9E9 /* Roboto-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 76509BC8278D4CF685E56AD9 /* Roboto-BoldItalic.ttf */; };
 		A72774053C0A480B90682CC4 /* Roboto-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9C12F8D39E3F46AA9ADA1233 /* Roboto-LightItalic.ttf */; };
 		B3C88654360E43C29548F8C8 /* Roboto-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F3F8D1B05DA044339A2953BF /* Roboto-Regular.ttf */; };
+		BA879FE528141CB00052E1E1 /* RNCPermissionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = BA879FDF28141CB00052E1E1 /* RNCPermissionHandler.m */; };
+		BA879FE628141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = BA879FE328141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.m */; };
+		BA879FE728141CB00052E1E1 /* RNCCameraRollManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BA879FE428141CB00052E1E1 /* RNCCameraRollManager.m */; };
 		BADD4E1093BD4F9096A80D38 /* NotoSansKR-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 5F41EF1252CC4F08B3BAF374 /* NotoSansKR-Regular.otf */; };
 		E6C58BF1C3784743B899A910 /* Roboto-Thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FC408770C16F4B2F8C6E5B3C /* Roboto-Thin.ttf */; };
 		FA810DDFD3E9B502570DEDE0 /* libPods-anilog.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B079AF24774A2B10B60DFF49 /* libPods-anilog.a */; };
@@ -64,6 +67,12 @@
 		AAC775FFF43F4592ABC47E11 /* Roboto-Light.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Roboto-Light.ttf"; path = "../asset/fonts/Roboto-Light.ttf"; sourceTree = "<group>"; };
 		B079AF24774A2B10B60DFF49 /* libPods-anilog.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-anilog.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B7CC3F2370A94A2B8E77E173 /* Roboto-MediumItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Roboto-MediumItalic.ttf"; path = "../asset/fonts/Roboto-MediumItalic.ttf"; sourceTree = "<group>"; };
+		BA879FDF28141CB00052E1E1 /* RNCPermissionHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RNCPermissionHandler.m; path = anilog/RNCPermissionHandler.m; sourceTree = "<group>"; };
+		BA879FE028141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNCAssetsLibraryRequestHandler.h; path = anilog/RNCAssetsLibraryRequestHandler.h; sourceTree = "<group>"; };
+		BA879FE128141CB00052E1E1 /* RNCPermissionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNCPermissionHandler.h; path = anilog/RNCPermissionHandler.h; sourceTree = "<group>"; };
+		BA879FE228141CB00052E1E1 /* RNCCameraRollManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNCCameraRollManager.h; path = anilog/RNCCameraRollManager.h; sourceTree = "<group>"; };
+		BA879FE328141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RNCAssetsLibraryRequestHandler.m; path = anilog/RNCAssetsLibraryRequestHandler.m; sourceTree = "<group>"; };
+		BA879FE428141CB00052E1E1 /* RNCCameraRollManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RNCCameraRollManager.m; path = anilog/RNCCameraRollManager.m; sourceTree = "<group>"; };
 		CD10A8244A6A41CDAC458879 /* Roboto-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Roboto-Black.ttf"; path = "../asset/fonts/Roboto-Black.ttf"; sourceTree = "<group>"; };
 		E31176A5D1C6961F817358D8 /* Pods-anilog.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-anilog.release.xcconfig"; path = "Target Support Files/Pods-anilog/Pods-anilog.release.xcconfig"; sourceTree = "<group>"; };
 		E3FFBA379F6EF570C62482AB /* Pods-anilog.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-anilog.debug.xcconfig"; path = "Target Support Files/Pods-anilog/Pods-anilog.debug.xcconfig"; sourceTree = "<group>"; };
@@ -120,6 +129,12 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
 				13B07FB71A68108700A75B9A /* main.m */,
+				BA879FE028141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.h */,
+				BA879FE328141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.m */,
+				BA879FE228141CB00052E1E1 /* RNCCameraRollManager.h */,
+				BA879FE428141CB00052E1E1 /* RNCCameraRollManager.m */,
+				BA879FE128141CB00052E1E1 /* RNCPermissionHandler.h */,
+				BA879FDF28141CB00052E1E1 /* RNCPermissionHandler.m */,
 			);
 			name = anilog;
 			sourceTree = "<group>";
@@ -475,7 +490,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				BA879FE728141CB00052E1E1 /* RNCCameraRollManager.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				BA879FE628141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.m in Sources */,
+				BA879FE528141CB00052E1E1 /* RNCPermissionHandler.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/anilog/RNCAssetsLibraryRequestHandler.h
+++ b/ios/anilog/RNCAssetsLibraryRequestHandler.h
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTBridge.h>
+#import <React/RCTURLRequestHandler.h>
+
+@class PHPhotoLibrary;
+
+@interface RNCAssetsLibraryRequestHandler : NSObject <RCTURLRequestHandler>
+
+@end

--- a/ios/anilog/RNCAssetsLibraryRequestHandler.m
+++ b/ios/anilog/RNCAssetsLibraryRequestHandler.m
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RNCAssetsLibraryRequestHandler.h"
+
+#import <stdatomic.h>
+#import <dlfcn.h>
+#import <objc/runtime.h>
+
+#import <Photos/Photos.h>
+#import <MobileCoreServices/MobileCoreServices.h>
+
+#import <React/RCTBridge.h>
+#import <React/RCTNetworking.h>
+#import <React/RCTUtils.h>
+
+@implementation RNCAssetsLibraryRequestHandler
+
+NSString *const PHUploadScheme = @"ph-upload";
+
+RCT_EXPORT_MODULE()
+
+#pragma mark - RNCURLRequestHandler
+
+- (BOOL)canHandleRequest:(NSURLRequest *)request
+{
+  if (![PHAsset class]) {
+    return NO;
+  }
+
+  return [request.URL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame
+    || [request.URL.scheme caseInsensitiveCompare:@"ph"] == NSOrderedSame
+    || [request.URL.scheme caseInsensitiveCompare:PHUploadScheme] == NSOrderedSame;
+}
+
+- (id)sendRequest:(NSURLRequest *)request
+     withDelegate:(id<RCTURLRequestDelegate>)delegate
+{
+  __block atomic_bool cancelled = ATOMIC_VAR_INIT(NO);
+  void (^cancellationBlock)(void) = ^{
+    atomic_store(&cancelled, YES);
+  };
+
+  NSURL *requestURL = request.URL;
+  BOOL isPHUpload = [requestURL.scheme caseInsensitiveCompare:PHUploadScheme] == NSOrderedSame;
+  if (isPHUpload) {
+    requestURL = [NSURL URLWithString:[@"ph" stringByAppendingString:[requestURL.absoluteString substringFromIndex:PHUploadScheme.length]]];
+  }
+  
+  if (!requestURL) {
+    NSString *const msg = [NSString stringWithFormat:@"Cannot send request without URL"];
+    [delegate URLRequest:cancellationBlock didCompleteWithError:RCTErrorWithMessage(msg)];
+    return cancellationBlock;
+  }
+  
+  PHFetchResult<PHAsset *> *fetchResult;
+ 
+  if ([requestURL.scheme caseInsensitiveCompare:@"ph"] == NSOrderedSame) {
+    // Fetch assets using PHAsset localIdentifier (recommended)
+    NSString *const localIdentifier = [requestURL.absoluteString substringFromIndex:@"ph://".length];
+    fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[localIdentifier] options:nil];
+  } else if ([requestURL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame) {
+    // This is the older, deprecated way of fetching assets from assets-library
+    // using the "assets-library://" protocol
+    fetchResult = [PHAsset fetchAssetsWithALAssetURLs:@[requestURL] options:nil];
+  } else {
+    NSString *const msg = [NSString stringWithFormat:@"Cannot send request with unknown protocol: %@", requestURL];
+    [delegate URLRequest:cancellationBlock didCompleteWithError:RCTErrorWithMessage(msg)];
+    return cancellationBlock;
+  }
+  
+  if (![fetchResult firstObject]) {
+    NSString *errorMessage = [NSString stringWithFormat:@"Failed to load asset"
+                              " at URL %@ with no error message.", requestURL];
+    NSError *error = RCTErrorWithMessage(errorMessage);
+    [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+    return cancellationBlock;
+  }
+  
+  if (atomic_load(&cancelled)) {
+    return cancellationBlock;
+  }
+
+  PHAsset *const _Nonnull asset = [fetchResult firstObject];
+
+  // When we're uploading a video, provide the full data but in any other case,
+  // provide only the thumbnail of the video.
+  if (asset.mediaType == PHAssetMediaTypeVideo && isPHUpload) {
+    PHVideoRequestOptions *const requestOptions = [PHVideoRequestOptions new];
+    requestOptions.networkAccessAllowed = YES;
+    [[PHImageManager defaultManager] requestAVAssetForVideo:asset options:requestOptions resultHandler:^(AVAsset * _Nullable avAsset, AVAudioMix * _Nullable audioMix, NSDictionary * _Nullable info) {
+      NSError *error = [info objectForKey:PHImageErrorKey];
+      if (error) {
+        [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+        return;
+      }
+
+      if (![avAsset isKindOfClass:[AVURLAsset class]]) {
+        error = [NSError errorWithDomain:RCTErrorDomain code:0 userInfo:
+        @{
+          NSLocalizedDescriptionKey: @"Unable to load AVURLAsset",
+          }];
+        [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+        return;
+      }
+
+      NSData *data = [NSData dataWithContentsOfURL:((AVURLAsset *)avAsset).URL
+                                           options:(NSDataReadingOptions)0
+                                             error:&error];
+      if (data) {
+        NSURLResponse *const response = [[NSURLResponse alloc] initWithURL:request.URL MIMEType:nil expectedContentLength:data.length textEncodingName:nil];
+        [delegate URLRequest:cancellationBlock didReceiveResponse:response];
+        [delegate URLRequest:cancellationBlock didReceiveData:data];
+      }
+      [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+    }];
+  } else {
+    // By default, allow downloading images from iCloud
+    PHImageRequestOptions *const requestOptions = [PHImageRequestOptions new];
+    requestOptions.networkAccessAllowed = YES;
+
+    [[PHImageManager defaultManager] requestImageDataForAsset:asset
+                                                      options:requestOptions
+                                                resultHandler:^(NSData * _Nullable imageData,
+                                                                NSString * _Nullable dataUTI,
+                                                                UIImageOrientation orientation,
+                                                                NSDictionary * _Nullable info) {
+      NSError *const error = [info objectForKey:PHImageErrorKey];
+      if (error) {
+        [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+        return;
+      }
+
+      NSInteger const length = [imageData length];
+      CFStringRef const dataUTIStringRef = (__bridge CFStringRef _Nonnull)(dataUTI);
+      CFStringRef const mimeType = UTTypeCopyPreferredTagWithClass(dataUTIStringRef, kUTTagClassMIMEType);
+
+      NSURLResponse *const response = [[NSURLResponse alloc] initWithURL:request.URL
+                                                                MIMEType:(__bridge NSString *)(mimeType)
+                                                   expectedContentLength:length
+                                                        textEncodingName:nil];
+      if (mimeType) CFRelease(mimeType);
+
+      [delegate URLRequest:cancellationBlock didReceiveResponse:response];
+
+      [delegate URLRequest:cancellationBlock didReceiveData:imageData];
+      [delegate URLRequest:cancellationBlock didCompleteWithError:nil];
+    }];
+  }
+  
+  return cancellationBlock;
+}
+
+- (void)cancelRequest:(id)requestToken
+{
+  ((void (^)(void))requestToken)();
+}
+
+@end

--- a/ios/anilog/RNCCameraRollManager.h
+++ b/ios/anilog/RNCCameraRollManager.h
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+//참고한 포크: https://github.com/valentynberehovyi/react-native-cameraroll
+
+#import <Photos/Photos.h>
+
+#import <React/RCTBridgeModule.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (PHFetchOptions)
+
++ (PHFetchOptions *)PHFetchOptionsFromMediaType:(NSString *)mediaType
+                                       fromTime:(NSUInteger)fromTime
+                                         toTime:(NSUInteger)toTime;
+
+@end
+
+
+@interface RNCCameraRollManager : NSObject <RCTBridgeModule>
+
+@property (nonatomic, strong) RCTPromiseResolveBlock resolve;
+@property (nonatomic, strong) RCTPromiseRejectBlock reject;
+
+- (void)  image:(UIImage *)image
+  didFinishSavingWithError:(NSError *)error
+  contextInfo:(void *)contextInfo;
+@end

--- a/ios/anilog/RNCCameraRollManager.m
+++ b/ios/anilog/RNCCameraRollManager.m
@@ -1,0 +1,657 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RNCCameraRollManager.h"
+
+#import <CoreLocation/CoreLocation.h>
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <Photos/Photos.h>
+#import <dlfcn.h>
+#import <objc/runtime.h>
+#import <MobileCoreServices/UTType.h>
+
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTLog.h>
+#import <React/RCTUtils.h>
+
+#import "RNCAssetsLibraryRequestHandler.h"
+
+//#MARK: PHAssetCollectionSubtype
+@implementation RCTConvert (PHAssetCollectionSubtype)
+
+RCT_ENUM_CONVERTER(PHAssetCollectionSubtype, (@{
+   @"album": @(PHAssetCollectionSubtypeAny),
+   @"all": @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
+   @"event": @(PHAssetCollectionSubtypeAlbumSyncedEvent),
+   @"faces": @(PHAssetCollectionSubtypeAlbumSyncedFaces),
+   @"library": @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
+   @"photo-stream": @(PHAssetCollectionSubtypeAlbumMyPhotoStream), // incorrect, but legacy
+   @"photostream": @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
+   @"saved-photos": @(PHAssetCollectionSubtypeAny), // incorrect, but legacy correspondence in PHAssetCollectionSubtype
+   @"savedphotos": @(PHAssetCollectionSubtypeAny), // This was ALAssetsGroupSavedPhotos, seems to have no direct correspondence in PHAssetCollectionSubtype
+}), PHAssetCollectionSubtypeAny, integerValue)
+
+
+@end
+
+//#MARK: PHFetchOptions
+@implementation RCTConvert (PHFetchOptions)
+
++ (PHFetchOptions *)PHFetchOptionsFromMediaType:(NSString *)mediaType
+                                       fromTime:(NSUInteger)fromTime
+                                         toTime:(NSUInteger)toTime
+{
+  // This is not exhaustive in terms of supported media type predicates; more can be added in the future
+  NSString *const lowercase = [mediaType lowercaseString];
+  NSMutableArray *format = [NSMutableArray new];
+  NSMutableArray *arguments = [NSMutableArray new];
+  
+  if ([lowercase isEqualToString:@"photos"]) {
+    [format addObject:@"mediaType = %d"];
+    [arguments addObject:@(PHAssetMediaTypeImage)];
+  } else if ([lowercase isEqualToString:@"videos"]) {
+    [format addObject:@"mediaType = %d"];
+    [arguments addObject:@(PHAssetMediaTypeVideo)];
+  } else {
+    if (![lowercase isEqualToString:@"all"]) {
+      RCTLogError(@"Invalid filter option: '%@'. Expected one of 'photos',"
+                  "'videos' or 'all'.", mediaType);
+    }
+  }
+  
+  if (fromTime > 0) {
+    NSDate* fromDate = [NSDate dateWithTimeIntervalSince1970:fromTime/1000];
+    [format addObject:@"creationDate > %@"];
+    [arguments addObject:fromDate];
+  }
+  if (toTime > 0) {
+    NSDate* toDate = [NSDate dateWithTimeIntervalSince1970:toTime/1000];
+    [format addObject:@"creationDate <= %@"];
+    [arguments addObject:toDate];
+  }
+  
+  // This case includes the "all" mediatype
+  PHFetchOptions *const options = [PHFetchOptions new];
+  if ([format count] > 0) {
+    options.predicate = [NSPredicate predicateWithFormat:[format componentsJoinedByString:@" AND "] argumentArray:arguments];
+  }
+  return options;
+}
+
+@end
+
+@implementation RNCCameraRollManager
+
+RCT_EXPORT_MODULE(RNCCameraRoll)
+
+@synthesize bridge = _bridge;
+
+static NSString *const kErrorUnableToSave = @"E_UNABLE_TO_SAVE";
+static NSString *const kErrorUnableToLoad = @"E_UNABLE_TO_LOAD";
+
+static NSString *const kErrorAuthRestricted = @"E_PHOTO_LIBRARY_AUTH_RESTRICTED";
+static NSString *const kErrorAuthDenied = @"E_PHOTO_LIBRARY_AUTH_DENIED";
+
+static NSString *const tempDirectoryPath = @"anilog_temp/";
+static NSString *const albumName = @"Anilog";
+
+typedef void (^PhotosAuthorizedBlock)(void);
+
+//#MARK: requestPhotoLibraryAccess
+static void requestPhotoLibraryAccess(RCTPromiseRejectBlock reject, PhotosAuthorizedBlock authorizedBlock) {
+  PHAuthorizationStatus authStatus = [PHPhotoLibrary authorizationStatus];
+  if (authStatus == PHAuthorizationStatusRestricted) {
+    reject(kErrorAuthRestricted, @"Access to photo library is restricted", nil);
+  } else if (authStatus == PHAuthorizationStatusAuthorized) {
+    authorizedBlock();
+  } else if (authStatus == PHAuthorizationStatusNotDetermined) {
+    [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+      requestPhotoLibraryAccess(reject, authorizedBlock);
+    }];
+  } else {
+    reject(kErrorAuthDenied, @"Access to photo library was denied", nil);
+  }
+}
+
+//#MARK: saveToCameraRoll
+RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
+                  options:(NSDictionary *)options
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+  // We load images and videos differently.
+  // Images have many custom loaders which can load images from ALAssetsLibrary URLs, PHPhotoLibrary
+  // URLs, `data:` URIs, etc. Video URLs are passed directly through for now; it may be nice to support
+  // more ways of loading videos in the future.
+  __block NSURL *inputURI = nil;
+  __block PHFetchResult *photosAsset;
+  __block PHAssetCollection *collection;
+  __block PHObjectPlaceholder *placeholder;
+
+  void (^saveBlock)(void) = ^void() {
+    // performChanges and the completionHandler are called on
+    // arbitrary threads, not the main thread - this is safe
+    // for now since all JS is queued and executed on a single thread.
+    // We should reevaluate this if that assumption changes.
+
+    [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+      PHAssetChangeRequest *assetRequest ;
+      if ([options[@"type"] isEqualToString:@"video"]) {
+        assetRequest = [PHAssetChangeRequest creationRequestForAssetFromVideoAtFileURL:inputURI];
+      } else {
+        NSData *data = [NSData dataWithContentsOfURL:inputURI];
+        UIImage *image = [UIImage imageWithData:data];
+        assetRequest = [PHAssetChangeRequest creationRequestForAssetFromImage:image];
+      }
+      
+      placeholder = [assetRequest placeholderForCreatedAsset];
+      if (![options[@"album"] isEqualToString:@""]) {
+        photosAsset = [PHAsset fetchAssetsInAssetCollection:collection options:nil];
+        PHAssetCollectionChangeRequest *albumChangeRequest = [PHAssetCollectionChangeRequest changeRequestForAssetCollection:collection assets:photosAsset];
+        [albumChangeRequest addAssets:@[placeholder]];
+      }
+    } completionHandler:^(BOOL success, NSError *error) {
+      if (success) {
+        NSString *uri = [NSString stringWithFormat:@"ph://%@", [placeholder localIdentifier]];
+        resolve(uri);
+      } else {
+        reject(kErrorUnableToSave, nil, error);
+      }
+    }];
+  };
+  void (^saveWithOptions)(void) = ^void() {
+    if (![options[@"album"] isEqualToString:@""]) {
+  
+      PHFetchOptions *fetchOptions = [[PHFetchOptions alloc] init];
+      fetchOptions.predicate = [NSPredicate predicateWithFormat:@"title = %@", options[@"album"] ];
+      collection = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
+                                                            subtype:PHAssetCollectionSubtypeAny
+                                                            options:fetchOptions].firstObject;
+      // Create the album
+      if (!collection) {
+        [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+          PHAssetCollectionChangeRequest *createAlbum = [PHAssetCollectionChangeRequest creationRequestForAssetCollectionWithTitle:options[@"album"]];
+          placeholder = [createAlbum placeholderForCreatedAssetCollection];
+        } completionHandler:^(BOOL success, NSError *error) {
+          if (success) {
+            PHFetchResult *collectionFetchResult = [PHAssetCollection fetchAssetCollectionsWithLocalIdentifiers:@[placeholder.localIdentifier]
+                                                                                                        options:nil];
+            collection = collectionFetchResult.firstObject;
+            saveBlock();
+          } else {
+            reject(kErrorUnableToSave, nil, error);
+          }
+        }];
+      } else {
+        saveBlock();
+      }
+    } else {
+      saveBlock();
+    }
+  };
+
+  void (^loadBlock)(void) = ^void() {
+    inputURI = request.URL;
+    saveWithOptions();
+  };
+
+  requestPhotoLibraryAccess(reject, loadBlock);
+}
+
+//#MARK: getAlbums
+RCT_EXPORT_METHOD(getAlbums:(NSDictionary *)params
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+  NSString *const mediaType = [params objectForKey:@"assetType"] ? [RCTConvert NSString:params[@"assetType"]] : @"All";
+  NSString *const albumType = [params objectForKey:@"albumType"] ? [RCTConvert NSString:params[@"albumType"]] : @"Album";
+
+  NSMutableArray * result = [NSMutableArray new];
+  NSString *__block fetchedAlbumType = nil;
+  
+  //콜백함수 선언
+  //반환형 (^블록명)(파라미터 타입); void (^blockName)(double, double);
+  //- (void)exampleMethodName:(블록 선언이 들어갈 자리인데 생략가능)블록 이름;
+  //- (void)exampleMethodName:(void (^blockName)(void))methodBlockName;
+  //- (void)exampleMethodName:(void (^)(void))methodBlockName;
+  //methodBlockName은 exampleMethodName 함수 안에서 쓸 블록 이름입니다.
+  //exampleMethodName 안에서 methodBlockName()으로 호출도 가능합니다.
+  void (^convertAsset)(PHAssetCollection * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) =
+    ^(PHAssetCollection * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+      PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType fromTime:0 toTime:0];
+      // Enumerate assets within the collection
+      PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset
+                                                           fetchAssetsInAssetCollection:obj
+                                                           options:assetFetchOptions];
+      //리턴형태
+      if (assetsFetchResult.count > 0) {
+        [result addObject:@{
+          @"title": [obj localizedTitle],
+          @"count": @(assetsFetchResult.count),
+          @"type": fetchedAlbumType,
+          @"subType": @(obj.assetCollectionSubtype)
+        }];
+      }
+    };
+
+  PHFetchOptions* options = [[PHFetchOptions alloc] init];
+  //album 받아오기
+  if ([albumType isEqualToString:@"Album"] || [albumType isEqualToString:@"All"]) {
+    fetchedAlbumType = @"Album";
+    PHFetchResult<PHAssetCollection *> *const assets = [PHAssetCollection
+                                                        fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
+                                                        subtype:PHAssetCollectionSubtypeAny
+                                                        options:options];
+    [assets enumerateObjectsUsingBlock:convertAsset];
+  }
+  //smart album 받아오기
+  if ([albumType isEqualToString:@"SmartAlbum"] || [albumType isEqualToString:@"All"]) {
+    fetchedAlbumType = @"SmartAlbum";
+    PHFetchResult<PHAssetCollection *> *const assets = [PHAssetCollection
+                                                        fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum
+                                                        subtype:PHAssetCollectionSubtypeAny
+                                                        options:options];
+    [assets enumerateObjectsUsingBlock:convertAsset];
+  }
+
+  resolve(result);
+}
+
+//#MARK: RCTResolvePromise
+
+static void RCTResolvePromise(RCTPromiseResolveBlock resolve,
+                              NSArray<NSDictionary<NSString *, id> *> *assets,
+                              BOOL hasNextPage)
+{
+  if (!assets.count) {
+    resolve(@{
+      @"edges": assets,
+      @"page_info": @{
+        @"has_next_page": @NO,
+      }
+    });
+    return;
+  }
+  resolve(@{
+    @"edges": assets,
+    @"page_info": @{
+      @"start_cursor": assets[0][@"node"][@"image"][@"uri"],
+      @"end_cursor": assets[assets.count - 1][@"node"][@"image"][@"uri"],
+      @"has_next_page": @(hasNextPage),
+    }
+  });
+}
+
+//#MARK: getPhotos
+RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+  checkPhotoLibraryConfig();
+
+  NSUInteger const first = [RCTConvert NSInteger:params[@"first"]];
+  NSString *const afterCursor = [RCTConvert NSString:params[@"after"]];
+  NSString *const groupName = [RCTConvert NSString:params[@"groupName"]];
+  NSString *const groupTypes = [[RCTConvert NSString:params[@"groupTypes"]] lowercaseString];
+  NSString *const mediaType = [RCTConvert NSString:params[@"assetType"]];
+  NSUInteger const subType = [RCTConvert NSInteger:params[@"subType"]];
+  NSUInteger const fromTime = [RCTConvert NSInteger:params[@"fromTime"]];
+  NSUInteger const toTime = [RCTConvert NSInteger:params[@"toTime"]];
+  NSArray<NSString *> *const mimeTypes = [RCTConvert NSStringArray:params[@"mimeTypes"]];
+  NSArray<NSString *> *const include = [RCTConvert NSStringArray:params[@"include"]];
+
+  BOOL __block includeFilename = [include indexOfObject:@"filename"] != NSNotFound;
+  BOOL __block includeFileSize = [include indexOfObject:@"fileSize"] != NSNotFound;
+  BOOL __block includeLocation = [include indexOfObject:@"location"] != NSNotFound;
+  BOOL __block includeImageSize = [include indexOfObject:@"imageSize"] != NSNotFound;
+  BOOL __block includePlayableDuration = [include indexOfObject:@"playableDuration"] != NSNotFound;
+  
+  // Predicate for fetching assets within a collection
+  PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType fromTime:fromTime toTime:toTime];
+  // We can directly set the limit if we guarantee every image fetched will be
+  // added to the output array within the `collectAsset` block
+  BOOL collectAssetMayOmitAsset = !!afterCursor || [mimeTypes count] > 0;
+  if (!collectAssetMayOmitAsset) {
+    // We set the fetchLimit to first + 1 so that `hasNextPage` will be set
+    // correctly:
+    // - If the user set `first: 10` and there are 11 photos, `hasNextPage`
+    //   will be set to true below inside of `collectAsset`
+    // - If the user set `first: 10` and there are 10 photos, `hasNextPage`
+    //   will not be set, as expected
+    assetFetchOptions.fetchLimit = first + 1;
+  }
+  assetFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
+  
+  BOOL __block foundAfter = NO;
+  BOOL __block hasNextPage = NO;
+  BOOL __block resolvedPromise = NO;
+  NSMutableArray<NSDictionary<NSString *, id> *> *assets = [NSMutableArray new];
+  
+  BOOL __block stopCollections_;
+  NSString __block *currentCollectionName;
+
+  requestPhotoLibraryAccess(reject, ^{
+    void (^collectAsset)(PHAsset*, NSUInteger, BOOL*) = ^(PHAsset * _Nonnull asset, NSUInteger assetIdx, BOOL * _Nonnull stopAssets) {
+      NSString *const uri = [NSString stringWithFormat:@"ph://%@", [asset localIdentifier]];
+      NSString *_Nullable originalFilename = NULL;
+      PHAssetResource *_Nullable resource = NULL;
+      NSNumber* fileSize = [NSNumber numberWithInt:0];
+      NSString* path = @"path";
+      
+      //#MARK: - getphoto
+      if (includeFilename || includeFileSize || [mimeTypes count] > 0) {
+        // Get underlying resources of an asset - this includes files as well as details about edited PHAssets
+        // This is required for the filename and mimeType filtering
+        NSArray<PHAssetResource *> *const assetResources = [PHAssetResource assetResourcesForAsset:asset];
+        resource = [assetResources firstObject];
+        originalFilename = resource.originalFilename;
+        fileSize = [resource valueForKey:@"fileSize"];
+      }
+      
+      // WARNING: If you add any code to `collectAsset` that may skip adding an
+      // asset to the `assets` output array, you should do it inside this
+      // block and ensure the logic for `collectAssetMayOmitAsset` above is
+      // updated
+      if (collectAssetMayOmitAsset) {
+        if (afterCursor && !foundAfter) {
+          if ([afterCursor isEqualToString:uri]) {
+            foundAfter = YES;
+          }
+          return; // skip until we get to the first one
+        }
+
+
+        if ([mimeTypes count] > 0 && resource) {
+          CFStringRef const uti = (__bridge CFStringRef _Nonnull)(resource.uniformTypeIdentifier);
+          NSString *const mimeType = (NSString *)CFBridgingRelease(UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType));
+
+          BOOL __block mimeTypeFound = NO;
+          [mimeTypes enumerateObjectsUsingBlock:^(NSString * _Nonnull mimeTypeFilter, NSUInteger idx, BOOL * _Nonnull stop) {
+            if ([mimeType isEqualToString:mimeTypeFilter]) {
+              mimeTypeFound = YES;
+              *stop = YES;
+            }
+          }];
+
+          if (!mimeTypeFound) {
+            return;
+          }
+        }
+      }
+
+      // If we've accumulated enough results to resolve a single promise
+      if (first == assets.count) {
+        *stopAssets = YES;
+        stopCollections_ = YES;
+        hasNextPage = YES;
+        RCTAssert(resolvedPromise == NO, @"Resolved the promise before we finished processing the results.");
+        RCTResolvePromise(resolve, assets, hasNextPage);
+        resolvedPromise = YES;
+        return;
+      }
+
+      NSString *const assetMediaTypeLabel = (asset.mediaType == PHAssetMediaTypeVideo
+                                            ? @"video"
+                                            : (asset.mediaType == PHAssetMediaTypeImage
+                                                ? @"image"
+                                                : (asset.mediaType == PHAssetMediaTypeAudio
+                                                  ? @"audio"
+                                                  : @"unknown")));
+      CLLocation *const loc = asset.location;
+
+      [assets addObject:@{
+        @"node": @{
+          @"type": assetMediaTypeLabel, // TODO: switch to mimeType?
+          @"group_name": currentCollectionName,
+          @"image": @{
+              @"uri": uri,
+              @"filename": (includeFilename && originalFilename ? originalFilename : [NSNull null]),
+              @"height": (includeImageSize ? @([asset pixelHeight]) : [NSNull null]),
+              @"width": (includeImageSize ? @([asset pixelWidth]) : [NSNull null]),
+              @"fileSize": (includeFileSize ? fileSize : [NSNull null]),
+              @"playableDuration": (includePlayableDuration && asset.mediaType != PHAssetMediaTypeImage
+                                    ? @([asset duration]) // fractional seconds
+                                    : [NSNull null]),
+              @"path": path
+          },
+          @"timestamp": @(asset.creationDate.timeIntervalSince1970),
+          @"location": (includeLocation && loc ? @{
+              @"latitude": @(loc.coordinate.latitude),
+              @"longitude": @(loc.coordinate.longitude),
+              @"altitude": @(loc.altitude),
+              @"heading": @(loc.course),
+              @"speed": @(loc.speed), // speed in m/s
+            } : [NSNull null])
+          }
+      }];
+    };
+
+    if ([groupTypes isEqualToString:@"all"]) {
+      PHFetchResult <PHAsset *> *const assetFetchResult = [PHAsset fetchAssetsWithOptions: assetFetchOptions];
+      currentCollectionName = @"All Photos";
+      [assetFetchResult enumerateObjectsUsingBlock:collectAsset];
+    } else {
+      PHFetchResult<PHAssetCollection *> * assetCollectionFetchResult;
+      if ([groupTypes isEqualToString:@"smartalbum"]) {
+        assetCollectionFetchResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:subType options:nil];
+        [assetCollectionFetchResult enumerateObjectsUsingBlock:^(PHAssetCollection * _Nonnull assetCollection, NSUInteger collectionIdx, BOOL * _Nonnull stopCollections) {
+            PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:assetCollection options:assetFetchOptions];
+            currentCollectionName = [assetCollection localizedTitle];
+            [assetsFetchResult enumerateObjectsUsingBlock:collectAsset];
+        
+          *stopCollections = stopCollections_;
+        }];
+      } else {
+        PHAssetCollectionSubtype const collectionSubtype = [RCTConvert PHAssetCollectionSubtype:groupTypes];
+
+        // Filter collection name ("group")
+        PHFetchOptions *const collectionFetchOptions = [PHFetchOptions new];
+        collectionFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"endDate" ascending:NO]];
+        if (groupName != nil) {
+          collectionFetchOptions.predicate = [NSPredicate predicateWithFormat:@"localizedTitle = %@", groupName];
+        }
+        assetCollectionFetchResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum subtype:collectionSubtype options:collectionFetchOptions];
+        [assetCollectionFetchResult enumerateObjectsUsingBlock:^(PHAssetCollection * _Nonnull assetCollection, NSUInteger collectionIdx, BOOL * _Nonnull stopCollections) {
+            // Enumerate assets within the collection
+          PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:assetCollection options:assetFetchOptions];
+          currentCollectionName = [assetCollection localizedTitle];
+          [assetsFetchResult enumerateObjectsUsingBlock:collectAsset];
+          *stopCollections = stopCollections_;
+        }];
+      } // else of "if ([groupTypes isEqualToString:@"all"])"
+    }
+
+    // If we get this far and haven't resolved the promise yet, we reached the end of the list of photos
+    if (!resolvedPromise) {
+      hasNextPage = NO;
+      RCTResolvePromise(resolve, assets, hasNextPage);
+      resolvedPromise = YES;
+    }
+  });
+}
+
+//#MARK: deletePhotos
+RCT_EXPORT_METHOD(deletePhotos:(NSArray<NSString *>*)assets
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+  NSMutableArray *convertedAssets = [NSMutableArray array];
+  
+  for (NSString *asset in assets) {
+    [convertedAssets addObject: [asset stringByReplacingOccurrencesOfString:@"ph://" withString:@""]];
+  }
+
+  [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+      PHFetchResult<PHAsset *> *fetched =
+        [PHAsset fetchAssetsWithLocalIdentifiers:convertedAssets options:nil];
+      [PHAssetChangeRequest deleteAssets:fetched];
+    }
+  completionHandler:^(BOOL success, NSError *error) {
+    if (success == YES) {
+      resolve(@(success));
+    }
+    else {
+      reject(@"Couldn't delete", @"Couldn't delete assets", error);
+    }
+  }
+  ];
+}
+
+//#MARK: - RCT compressImage
+///options로 인자 받는 방식으로 변경 예정. 이미지를 정해진 크기로 변환한다. 세로 기준으로 파일 사이즈를 줄인다.
+///현재는 cameraroll에서 리턴받는 ph://{local identifier} 주소로만 동작한다.
+///quality는 1.0~0.0
+RCT_EXPORT_METHOD(compressImage:(NSString* _Nonnull)uri
+                  compressWidth:(NSNumber* _Nonnull)width
+                  compressHeight:(NSNumber* _Nonnull)height
+                  compressionQuality:(NSNumber* _Nonnull)quality
+                  resolver:(RCTPromiseResolveBlock) resolve
+                  rejecter:(RCTPromiseRejectBlock) reject){
+  if ([uri containsString:@"ph://"] == false) {
+    reject(@"Invalid image uri format.", @"Correct format is 'ph://{local identifier}'", nil);
+    return;
+  }
+  
+  //프로퍼티에 저장하지 않는 방법 강구
+  self.resolve = resolve;
+  self.reject = reject;
+  
+  CGFloat oldWidth = 0;
+  CGFloat oldHeight = 0;
+  
+  CGFloat newWidth = width.floatValue;
+  CGFloat newHeight = height.floatValue;
+  
+  //camera roll에서 반환하는 uri는 ph:// + (localIdentifier) 라서 5번째 인덱스부터
+  PHFetchResult<PHAsset *> *asset = [PHAsset fetchAssetsWithLocalIdentifiers:@[[uri substringFromIndex:5]] options:nil];
+  
+  if(asset == nil || asset.count == 0) {
+    self.reject(@"Image fetch result error", @"Image fetch result is nil.", nil);
+    return;
+  } else if(asset.firstObject == nil) {
+    self.reject(@"Nil error", @"Image is nil", nil);
+    return;
+  }
+  
+  oldWidth = asset.firstObject.pixelWidth;
+  oldHeight = asset.firstObject.pixelHeight;
+  
+  if (newWidth < newHeight) {
+      newHeight = (oldHeight / oldWidth) * newWidth;
+  } else {
+      newWidth = (oldWidth / oldHeight) * newHeight;
+  }
+  CGSize newSize = CGSizeMake(newWidth, newHeight);
+
+  PHImageRequestOptions* options = [PHImageRequestOptions new];
+  options.synchronous = true;
+  [[PHImageManager defaultManager] requestImageForAsset:asset.firstObject
+                                             targetSize:newSize
+                                            contentMode:PHImageContentModeAspectFit
+                                                options:options
+                                          resultHandler:^(UIImage * _Nullable result, NSDictionary * _Nullable info) {
+    
+    if(result == nil){
+      self.reject(@"nil error", @"image result is nil", nil);
+      return;
+    }
+    
+    //압축된 데이터
+    NSData *imageData = UIImageJPEGRepresentation(result, quality.floatValue);
+    NSString* savedPath = [self createTempImage:imageData];
+
+    if (savedPath == nil) {
+      self.reject(@"Fail to save", @"Failed to save compressed image", nil);
+      return;
+    } else {
+      self.resolve(savedPath);
+    }
+    }];
+}
+
+//#MARK: checkPhotoLibraryConfig
+static void checkPhotoLibraryConfig()
+{
+#if RCT_DEV
+  if (![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSPhotoLibraryUsageDescription"]) {
+    RCTLogError(@"NSPhotoLibraryUsageDescription key must be present in Info.plist to use camera roll.");
+  }
+#endif
+}
+
+//#MARK: @createTempImage
+- (NSString*) createTempImage:(NSData*)data {
+    NSString *tmpDirFullPath = [self getTmpDirectory];
+    NSString *filePath = [tmpDirFullPath stringByAppendingString:[[NSUUID UUID] UUIDString]];
+    filePath = [filePath stringByAppendingString:@".jpg"];
+    
+    BOOL status = [data writeToFile:filePath atomically:YES];
+    if (!status) {
+        return nil;
+    }
+    
+    return filePath;
+}
+
+
+//#MARK: @getTmpDirectory
+- (NSString*) getTmpDirectory {
+  NSString *tmpFullPath = [NSTemporaryDirectory() stringByAppendingString:tempDirectoryPath];
+    
+    BOOL isDir;
+    BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:tmpFullPath isDirectory:&isDir];
+    if (!exists) {
+        [[NSFileManager defaultManager] createDirectoryAtPath: tmpFullPath
+                                  withIntermediateDirectories:YES attributes:nil error:nil];
+    }
+    
+    return tmpFullPath;
+}
+
+//#MARK: @cleanTmpdirectory
+- (BOOL)cleanTmpDirectory {
+    NSString* tmpDirectoryPath = [self getTmpDirectory];
+    NSArray* tmpDirectory = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:tmpDirectoryPath error:nil];
+    
+    for (NSString *file in tmpDirectory) {
+        BOOL deleted = [[NSFileManager defaultManager] removeItemAtPath:[NSString stringWithFormat:@"%@%@", tmpDirectoryPath, file] error:nil];
+        
+        if (!deleted) {
+            return false;
+        }
+    }
+    
+    return true;
+}
+
+////#MARK: @RCT cleanSingle
+//RCT_EXPORT_METHOD(cleanSingle:(NSString *) path
+//                  resolver:(RCTPromiseResolveBlock)resolve
+//                  rejecter:(RCTPromiseRejectBlock)reject) {
+//    BOOL deleted = [[NSFileManager defaultManager] removeItemAtPath:path error:NULL];
+//
+//    if (!deleted) {
+//      reject(@"Cleanup error", @"Cleanup error msg", nil);
+//    } else {
+//        resolve(nil);
+//    }
+//}
+
+//#MARK: @RCT clean
+RCT_REMAP_METHOD(clean,
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+    if (![self cleanTmpDirectory]) {
+        reject(@"ERROR_CLEANUP_ERROR_KEY", @"ERROR_CLEANUP_ERROR_MSG", nil);
+    } else {
+        resolve(nil);
+    }
+}
+
+@end

--- a/ios/anilog/RNCPermissionHandler.h
+++ b/ios/anilog/RNCPermissionHandler.h
@@ -1,0 +1,7 @@
+
+
+#import <React/RCTBridgeModule.h>
+
+@interface RNCPermissionHandler : NSObject<RCTBridgeModule>
+
+@end

--- a/ios/anilog/RNCPermissionHandler.m
+++ b/ios/anilog/RNCPermissionHandler.m
@@ -1,0 +1,163 @@
+
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVCaptureDevice.h>
+#import <Photos/Photos.h>
+#import <React/RCTConvert.h>
+
+#import "RNCPermissionHandler.h"
+
+
+//MARK: - ENUMs
+/*
+ * 현재는 기본 요청 퍼미션이 PhotoLibrary로 되어 있음.
+ * 향후 Camera / Audio / PhotoLibraryAdditions 추가 예정
+ */
+typedef NS_ENUM(NSInteger, RNCPermissionTypes){
+  RNCPermissionPhotoLibrary = 0,
+  RNCPermissionPhotoLibraryAdditions,
+  RNCPermissionCamera,
+  RNCPermissionAudio
+};
+
+typedef NS_ENUM(NSInteger, RNCPHPermissionIosStatus){
+  RNCPHPermissionIosStatusNotDetermined = 0,
+  RNCPHPermissionIosStatusRestricted,
+  RNCPHPermissionIosStatusDenied,
+  RNCPHPermissionIosStatusAuthorized,
+  RNCPHPermissionIosStatusLimited,// API_AVAILABLE(ios(14)),
+};
+
+/*
+ * 각 값에 해당하는 문자열은 PermissionIosStatics.ts 파일의 PERMISSION_IOS_STATUS와 동일한 문자열
+ * 변경 시 두 파일의 값을 모두 변경하여 서로 다른 값이 되지 않도록 주의
+ */
+@implementation RCTConvert(PHPermissionIosStatus)
+RCT_ENUM_CONVERTER(RNCPHPermissionIosStatus,
+                   (@{
+                    @"notDetermined":@(RNCPHPermissionIosStatusNotDetermined),
+                    @"restricted":@(RNCPHPermissionIosStatusRestricted),
+                    @"denied":@(RNCPHPermissionIosStatusDenied),
+                    @"authorized":@(RNCPHPermissionIosStatusAuthorized),
+                    @"limited":@(RNCPHPermissionIosStatusLimited),
+                   }), RNCPHPermissionIosStatusNotDetermined, integerValue)
+
+@end
+
+//MARK: -IosPermissionHandler Module
+
+@implementation RNCPermissionHandler
+
+RCT_EXPORT_MODULE(IosPermissionHandler);
+
+//enum RNCPHPermissionIosStatus를 문자열로 바꾸는 함수
+- (NSString *)stringForStatus:(RNCPHPermissionIosStatus)status {
+  switch (status) {
+    case RNCPHPermissionIosStatusNotDetermined:
+      return @"notDetermined";
+    case RNCPHPermissionIosStatusRestricted:
+      return @"restricted";
+    case RNCPHPermissionIosStatusDenied:
+      return @"denied";
+    case RNCPHPermissionIosStatusAuthorized:
+      return @"authorized";
+    case RNCPHPermissionIosStatusLimited:
+      return @"limited";
+  }
+}
+
+//PHAuthorizationStatus 를 상단 enum RNCPHPermissionIosStatus에 해당하는 값으로 바꾸어 자바스크립트 단으로 넘겨주는 함수
+- (void)switchPHPermissionResolve:(PHAuthorizationStatus)status
+                                  resolve:(RCTPromiseResolveBlock)resolve {
+  switch (status) {
+    case PHAuthorizationStatusAuthorized:
+      resolve([self stringForStatus:RNCPHPermissionIosStatusAuthorized]);
+      break;
+      
+    case PHAuthorizationStatusNotDetermined:
+      resolve([self stringForStatus:RNCPHPermissionIosStatusNotDetermined]);
+      break;
+      
+    case PHAuthorizationStatusDenied:
+      resolve([self stringForStatus:RNCPHPermissionIosStatusDenied]);
+      break;
+      
+    case PHAuthorizationStatusRestricted:
+      resolve([self stringForStatus:RNCPHPermissionIosStatusRestricted]);
+      break;
+      
+    case PHAuthorizationStatusLimited:
+      resolve([self stringForStatus:RNCPHPermissionIosStatusLimited]);
+    break;
+  }
+}
+
+//설정 창으로 이동하는 함수.
+RCT_EXPORT_METHOD(openSetting){
+  //UI는 main queue에서만 업데이트 가능
+  dispatch_async(dispatch_get_main_queue(), ^{
+  [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]
+                                     options: @{}
+                                     completionHandler: nil];
+  });
+}
+
+//퍼미션을 요청하고 해당 요청의 결과값을 리턴한다. reject 대응되어 있지 않음
+RCT_EXPORT_METHOD(requestPermission:
+                  (RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject){
+   if(@available(ios 14, *)){
+     [PHPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelReadWrite
+                                                handler:^(PHAuthorizationStatus status) {
+       [self switchPHPermissionResolve:status resolve:resolve];
+     }];
+  } else {
+        [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+          [self switchPHPermissionResolve:status resolve:resolve];
+        }];
+  }
+}
+
+//퍼미션을 체크하고 그에 대한 값을 리턴한다. reject 대응되어 있지 않음
+RCT_EXPORT_METHOD(checkPermission:
+                  (RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject){
+  PHAuthorizationStatus status;
+  if( @available(ios 14, *)){
+    status = [PHPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelReadWrite];
+  } else {
+    status = [PHPhotoLibrary authorizationStatus];
+  }
+  [self switchPHPermissionResolve:status resolve:resolve];
+}
+
+
+//카메라 퍼미션 작성 중
+RCT_EXPORT_METHOD(checkCameraPermission){
+  AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+  
+  switch (status){
+    case AVAuthorizationStatusAuthorized:
+
+      NSLog(@"Authorized");
+    
+      break;
+      
+    case AVAuthorizationStatusNotDetermined:
+      NSLog(@"Not determined");
+      
+      break;
+      
+    case AVAuthorizationStatusDenied:
+      NSLog(@"denied");
+      break;
+      
+    case AVAuthorizationStatusRestricted:
+      NSLog(@"restricted");
+      break;
+    }
+  }
+
+
+@end
+

--- a/src/module/CameraRollIos.js
+++ b/src/module/CameraRollIos.js
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+ 'use strict';
+ import { Platform } from 'react-native';
+ import RNCCameraRoll from './CameraRollNative';
+ 
+ const invariant = require('fbjs/lib/invariant');
+ 
+ const GROUP_TYPES_OPTIONS = {
+   Album: 'Album',
+   All: 'All', // default
+   Event: 'Event',
+   Faces: 'Faces',
+   Library: 'Library',
+   SmartAlbum: 'SmartAlbum',
+   PhotoStream: 'PhotoStream',
+   SavedPhotos: 'SavedPhotos',
+ };
+ 
+ const ASSET_TYPE_OPTIONS = {
+   All: 'All',
+   Videos: 'Videos',
+   Photos: 'Photos',
+ };
+ 
+ const ALBUM_TYPE_OPTIONS = {
+   All: 'All',
+   Album: 'Album',
+   SmartAlbum: 'SmartAlbum',
+ };
+ 
+ export type GroupTypes = $Keys<typeof GROUP_TYPES_OPTIONS>;
+ 
+ export type Include =
+   | 'filename'
+   | 'fileSize'
+   | 'location'
+   | 'imageSize'
+   | 'playableDuration';
+ 
+ /**
+  * Shape of the param arg for the `getPhotos` function.
+  */
+ export type GetPhotosParams = {
+   /**
+    * The number of photos wanted in reverse order of the photo application
+    * (i.e. most recent first).
+    */
+   first: number,
+ 
+   /**
+    * A cursor that matches `page_info { end_cursor }` returned from a previous
+    * call to `getPhotos`
+    */
+   after?: string,
+ 
+   /**
+    * Specifies which group types to filter the results to.
+    */
+   groupTypes?: GroupTypes,
+ 
+   /**
+    * Specifies filter on group names, like 'Recent Photos' or custom album
+    * titles.
+    */
+   groupName?: string,
+ 
+   /**
+    * Specifies filter on group subtype, basically for smart albums
+    */
+   subType?: string,
+ 
+   /**
+    * Specifies filter on asset type
+    */
+   assetType?: $Keys<typeof ASSET_TYPE_OPTIONS>,
+ 
+   /**
+    * Earliest time to get photos from. A timestamp in milliseconds. Exclusive.
+    */
+   fromTime?: number,
+ 
+   /**
+    * Latest time to get photos from. A timestamp in milliseconds. Inclusive.
+    */
+   toTime?: Number,
+ 
+   /**
+    * Filter by mimetype (e.g. image/jpeg).
+    */
+   mimeTypes?: Array<string>,
+ 
+   /**
+    * Specific fields in the output that we want to include, even though they
+    * might have some performance impact.
+    */
+   include?: Include[],
+ };
+ 
+ export type PhotoIdentifier = {
+   node: {
+     type: string,
+     group_name: string,
+     image: {
+       filename: string | null,
+       uri: string,
+       height: number,
+       width: number,
+       fileSize: number | null,
+       playableDuration: number,
+     },
+     timestamp: number,
+     location: {
+       latitude?: number,
+       longitude?: number,
+       altitude?: number,
+       heading?: number,
+       speed?: number,
+     } | null,
+   },
+ };
+ 
+ export type PhotoIdentifiersPage = {
+   edges: Array<PhotoIdentifier>,
+   page_info: {
+     has_next_page: boolean,
+     start_cursor?: string,
+     end_cursor?: string,
+   },
+ };
+ export type SaveToCameraRollOptions = {
+   type?: 'photo' | 'video' | 'auto',
+   album?: string,
+ };
+ 
+ export type GetAlbumsParams = {
+   assetType?: $Keys<typeof ASSET_TYPE_OPTIONS>,
+   albumType?: $Keys<typeof ALBUM_TYPE_OPTIONS>,
+ };
+ 
+ export type Album = {
+   title: string,
+   type: string,
+   subType: string,
+   count: number,
+ };
+ 
+ /**
+  * `CameraRoll` provides access to the local camera roll or photo library.
+  *
+  * See https://facebook.github.io/react-native/docs/cameraroll.html
+  */
+ class CameraRoll {
+   static GroupTypesOptions = GROUP_TYPES_OPTIONS;
+   static AssetTypeOptions = ASSET_TYPE_OPTIONS;
+   static AlbumTypeOptions = ALBUM_TYPE_OPTIONS;
+ 
+   static compressImage(uri: string, 
+     compressWidth: number,  compressHeight: number, compressionQuality: number): Promise<string>{
+ 
+     return RNCCameraRoll.compressImage(uri, compressWidth, compressHeight, compressionQuality);
+   }
+   
+   static getAlbums(
+     params: GetAlbumsParams = {
+       assetType: ASSET_TYPE_OPTIONS.All,
+       albumType: ALBUM_TYPE_OPTIONS.Album,
+     },
+   ): Promise<Album[]> {
+     return RNCCameraRoll.getAlbums(params);
+   }
+ 
+   static getParamsWithDefaults(params: GetPhotosParams): GetPhotosParams {
+     const newParams = { ...params };
+     if (!newParams.assetType) {
+       newParams.assetType = ASSET_TYPE_OPTIONS.All;
+     }
+     if (!newParams.groupTypes && Platform.OS !== 'android') {
+       newParams.groupTypes = GROUP_TYPES_OPTIONS.All;
+     }
+     return newParams;
+   }
+ 
+   /**
+    * Returns a Promise with photo identifier objects from the local camera
+    * roll of the device matching shape defined by `getPhotosReturnChecker`.
+    *
+    * See https://facebook.github.io/react-native/docs/cameraroll.html#getphotos
+    */
+   static getPhotos(params: GetPhotosParams): Promise<PhotoIdentifiersPage> {
+     params = CameraRoll.getParamsWithDefaults(params);
+     const promise = RNCCameraRoll.getPhotos(params);
+ 
+     if (arguments.length > 1) {
+       console.warn(
+         'CameraRoll.getPhotos(tag, success, error) is deprecated.  Use the returned Promise instead',
+       );
+       let successCallback = arguments[1];
+       const errorCallback = arguments[2] || (() => { });
+       promise.then(successCallback, errorCallback);
+     }
+ 
+     return promise;
+   }
+ 
+   static clean(){
+     return RNCCameraRoll.clean();
+   }
+ }
+ 
+ module.exports = CameraRoll;

--- a/src/module/CameraRollNative.js
+++ b/src/module/CameraRollNative.js
@@ -1,0 +1,1 @@
+export default require('react-native').NativeModules.RNCCameraRoll;

--- a/src/module/PermissionIos.js
+++ b/src/module/PermissionIos.js
@@ -1,0 +1,108 @@
+import { Alert, NativeModules } from 'react-native';
+import PermissionHandlerIos from './PermissionIosNative';
+import { PERMISSION_IOS_TYPES, PERMISSION_IOS_STATUS } from './PermissionIosStatics';
+
+export type AlertParams = {
+    title: string,
+    msg: string,
+    okFunc?: Function,
+    cancelFunc?: Function,
+    okBtnLabel: string,
+    cancelBtnLabel: string,
+  };
+
+class PermissionIos {
+    /**
+     * 퍼미션 상태를 체크하고 리퀘스트/팝업을 띄워주는 함수. 
+     * 별도로 관리하지 않을 경우 디폴트 플로우로 진행되므로 그대로 가져다 사용해도 무방.
+     */
+    static updatePermission(){
+        PermissionIos.checkPermission()
+        .then(status => {
+            console.log("current status:", status);
+
+            if(status == PERMISSION_IOS_STATUS.NotDetermined){
+                PermissionIos.requestPermission()
+                .then(statusAfterRequest => {
+                    console.log("after request status: ", statusAfterRequest);
+                })
+            }
+            else if(status != PERMISSION_IOS_STATUS.Authorized){
+                PermissionIos.popupAlert(PermissionIos.getDefaultAlertParams());
+            }
+        })
+        .catch(err => {
+            console.log(err);
+        })
+    }
+
+    /**
+     * 퍼미션 상태 확인.
+     * @returns PERMISSION_IOS_STATUS 를 리턴한다
+     */
+     static checkPermission():Promise<string> {
+        // console.log("checkPermission");
+        return PermissionHandlerIos.checkPermission();
+    }
+
+    /**
+     * 설정 창으로 이동. 설정 창으로 넘어간 뒤, 바뀐 퍼미션은 별도로 체크해야 함
+     */
+    static openSetting(){
+        // console.log("openSetting");
+        PermissionHandlerIos.openSetting();
+    }
+
+    /**
+     * 퍼미션 요청. iOS 14부터 버튼 3개인 기본 팝업 / iOS 14 미만은 버튼 2개인 기본 팝업
+     * plist에 적은 description으로 메세지가 출력된다.
+     * @warning 한 번이라도 퍼미션을 요청하여 해당 창이 뜬 적 있는 경우 반복 요청해도 팝업이 뜨지 않음
+     * @returns PERMISSION_IOS_STATUS 를 리턴한다.
+     */
+    static requestPermission():Promise<string>{
+        // console.log("requestPermission");
+        return PermissionHandlerIos.requestPermission();
+    }
+
+    /**
+     * Alert popup을 띄울 때의 기본값. 카카오톡에서 퍼미션 권한이 없을 때 뜨는 창과 동일한 창이다.
+     * @returns AlertParams의 기본값
+     */
+    static getDefaultAlertParams():AlertParams{
+        return {
+            title: "",
+            msg: "갤러리에 접근하려면 '갤러리' 접근 권한을 허용해야 합니다.",
+            okFunc: PermissionIos.openSetting,
+            cancelFunc: null,
+            okBtnLabel: "설정",
+            cancelBtnLabel: "취소"
+          };
+    }
+
+/**
+ * 버튼 2개짜리 ios native alert를 띄운다.
+ */
+    static popupAlert(params: AlertParams){
+        Alert.alert(
+            params.title,
+            params.msg,
+            [
+                { //cancel button
+                    text: params.cancelBtnLabel,
+                    onPress: () => { 
+                        if(params.cancelFunc != null) {
+                            params.cancelFunc();}
+                    }
+                },
+                { //ok button
+                    text: params.okBtnLabel,
+                    onPress: () => { 
+                        if(params.okFunc != null) {
+                            params.okFunc();}
+                    }
+                }
+            ]
+        )
+    }
+}
+module.exports = PermissionIos;

--- a/src/module/PermissionIosNative.js
+++ b/src/module/PermissionIosNative.js
@@ -1,0 +1,2 @@
+
+export default require('react-native').NativeModules.IosPermissionHandler;

--- a/src/module/PermissionIosStatics.ts
+++ b/src/module/PermissionIosStatics.ts
@@ -1,0 +1,14 @@
+export const PERMISSION_IOS_STATUS = Object.freeze({
+    NotDetermined: 'notDetermined',
+    Restricted: 'restricted',
+    Denied: 'denied',
+    Authorized: 'authorized',
+    Limited: 'limited', /** ios 14 이상부터 체크 가능 */
+  } as const);
+  
+export const PERMISSION_IOS_TYPES = Object.freeze({
+    PhotoLibrary: 'PhotoLibrary',//'PHAuthorizationStatus',
+    PhotoLibraryAdditions: 'PhotoLibraryAdditions',
+    Camera: 'Camera',//'AVAuthorizationStatus', //AVMediaTypeVideo
+    Audio: 'Audio',//'AVAuthorizationStatus', //AVMediaTypeAudio
+} as const);


### PR DESCRIPTION
*수정 사항: ios CameraRoll, Permission 관련 수정

*수정 결과:
Permission: 기존 카메라롤에서 별도로 제공하지 않던 함수. 추후 AndroidPermission처럼 한 곳에서 관리하기 위해 만들었습니다. 
CameraRoll: smart album 이미지 불러오기, 이미지 압축, 임시 폴더에 저장 확인. 현재 기능하지 않는 함수는 삭제하였습니다.
**Cameraroll의 경우 빌드하기 위해서는 기존 react-native-cameraroll 의 의존을 모두 삭제해야 합니다. 그렇지 않으면 "[Duplicate symbols for architecture x86_64]" 이슈 뜨면서 새로 추가한 objective c 코드들이 오류를 뿜습니다.

*추가된 파일: ./ios/anilog/RNCAssetsLibraryRequestHandler ( .h 와 .m )
./ios/anilog/RNCCameraRollManager ( .h 와 .m )
./ios/anilog/RNCPermissionHandler( .h 와 .m )
./src/module 하위 파일 ( CameraRollIos.js , CameraRollNative.js, PermissionIos.js, PermissionIosNative.js, PermissionIosStatics.ts)
테스트용 App.js (IosModuleTest_App.js)