### PR TITLE
[하늘] compress, save 함수 파라미터 변경 / deprecated 대응

### DIFF
--- a/IosModuleTest_App.js
+++ b/IosModuleTest_App.js
@@ -74,17 +74,25 @@ export default class App extends Component {
       return;
     }
 
-    CameraRoll.compressImage(this.state.image.uri, 160, 240, 0.5)
+    CameraRoll.compressImage({imageFiles: [this.state.image.uri],
+		 maxHeight: 160, 
+		 maxWidth: 240, 
+		 quality:0.5,
+     mimeType:"png" })
     .then(r => {
       console.log(r);
-      this.setState({
-        image: {
-          uri: r,
-          width: 10,
-          height: 500,
-        },
-        images: null,
-      });
+	  if (r== null || r.assets == null || r. assets.length == 0){
+		  console.log("assets are nil or length 0");
+	  } else {
+		this.setState({
+			image: {
+			  uri: r.assets[0].uri,
+			  width: r.assets[0].width,
+			  height: r.assets[0].height,
+			},
+			images: null,
+		  });
+	  }
     })
     .catch(err => {
       console.log(err);
@@ -191,8 +199,6 @@ export default class App extends Component {
 
         <TouchableOpacity
           onPress={() => {
-            test++;
-            console.log(test);
             this.compress();
           }}
           style={styles.button}>

--- a/ios/anilog/RNCCameraRollManager.h
+++ b/ios/anilog/RNCCameraRollManager.h
@@ -22,10 +22,10 @@
 
 @interface RNCCameraRollManager : NSObject <RCTBridgeModule>
 
-@property (nonatomic, strong) RCTPromiseResolveBlock resolve;
-@property (nonatomic, strong) RCTPromiseRejectBlock reject;
-
-- (void)  image:(UIImage *)image
-  didFinishSavingWithError:(NSError *)error
-  contextInfo:(void *)contextInfo;
+//@property (nonatomic, strong) RCTPromiseResolveBlock resolve;
+//@property (nonatomic, strong) RCTPromiseRejectBlock reject;
+//
+//- (void)  image:(UIImage *)image
+//  didFinishSavingWithError:(NSError *)error
+//  contextInfo:(void *)contextInfo;
 @end

--- a/ios/anilog/RNCCameraRollManager.m
+++ b/ios/anilog/RNCCameraRollManager.m
@@ -24,15 +24,15 @@
 @implementation RCTConvert (PHAssetCollectionSubtype)
 
 RCT_ENUM_CONVERTER(PHAssetCollectionSubtype, (@{
-   @"album": @(PHAssetCollectionSubtypeAny),
-   @"all": @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
-   @"event": @(PHAssetCollectionSubtypeAlbumSyncedEvent),
-   @"faces": @(PHAssetCollectionSubtypeAlbumSyncedFaces),
-   @"library": @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
-   @"photo-stream": @(PHAssetCollectionSubtypeAlbumMyPhotoStream), // incorrect, but legacy
-   @"photostream": @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
-   @"saved-photos": @(PHAssetCollectionSubtypeAny), // incorrect, but legacy correspondence in PHAssetCollectionSubtype
-   @"savedphotos": @(PHAssetCollectionSubtypeAny), // This was ALAssetsGroupSavedPhotos, seems to have no direct correspondence in PHAssetCollectionSubtype
+  @"album": @(PHAssetCollectionSubtypeAny),
+  @"all": @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
+  @"event": @(PHAssetCollectionSubtypeAlbumSyncedEvent),
+  @"faces": @(PHAssetCollectionSubtypeAlbumSyncedFaces),
+  @"library": @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
+  @"photo-stream": @(PHAssetCollectionSubtypeAlbumMyPhotoStream), // incorrect, but legacy
+  @"photostream": @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
+  @"saved-photos": @(PHAssetCollectionSubtypeAny), // incorrect, but legacy correspondence in PHAssetCollectionSubtype
+  @"savedphotos": @(PHAssetCollectionSubtypeAny), // This was ALAssetsGroupSavedPhotos, seems to have no direct correspondence in PHAssetCollectionSubtype
 }), PHAssetCollectionSubtypeAny, integerValue)
 
 
@@ -131,13 +131,13 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
   __block PHFetchResult *photosAsset;
   __block PHAssetCollection *collection;
   __block PHObjectPlaceholder *placeholder;
-
+  
   void (^saveBlock)(void) = ^void() {
     // performChanges and the completionHandler are called on
     // arbitrary threads, not the main thread - this is safe
     // for now since all JS is queued and executed on a single thread.
     // We should reevaluate this if that assumption changes.
-
+    
     [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
       PHAssetChangeRequest *assetRequest ;
       if ([options[@"type"] isEqualToString:@"video"]) {
@@ -165,7 +165,7 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
   };
   void (^saveWithOptions)(void) = ^void() {
     if (![options[@"album"] isEqualToString:@""]) {
-  
+      
       PHFetchOptions *fetchOptions = [[PHFetchOptions alloc] init];
       fetchOptions.predicate = [NSPredicate predicateWithFormat:@"title = %@", options[@"album"] ];
       collection = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
@@ -193,12 +193,12 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
       saveBlock();
     }
   };
-
+  
   void (^loadBlock)(void) = ^void() {
     inputURI = request.URL;
     saveWithOptions();
   };
-
+  
   requestPhotoLibraryAccess(reject, loadBlock);
 }
 
@@ -209,7 +209,7 @@ RCT_EXPORT_METHOD(getAlbums:(NSDictionary *)params
 {
   NSString *const mediaType = [params objectForKey:@"assetType"] ? [RCTConvert NSString:params[@"assetType"]] : @"All";
   NSString *const albumType = [params objectForKey:@"albumType"] ? [RCTConvert NSString:params[@"albumType"]] : @"Album";
-
+  
   NSMutableArray * result = [NSMutableArray new];
   NSString *__block fetchedAlbumType = nil;
   
@@ -221,23 +221,23 @@ RCT_EXPORT_METHOD(getAlbums:(NSDictionary *)params
   //methodBlockName은 exampleMethodName 함수 안에서 쓸 블록 이름입니다.
   //exampleMethodName 안에서 methodBlockName()으로 호출도 가능합니다.
   void (^convertAsset)(PHAssetCollection * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) =
-    ^(PHAssetCollection * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-      PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType fromTime:0 toTime:0];
-      // Enumerate assets within the collection
-      PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset
-                                                           fetchAssetsInAssetCollection:obj
-                                                           options:assetFetchOptions];
-      //리턴형태
-      if (assetsFetchResult.count > 0) {
-        [result addObject:@{
-          @"title": [obj localizedTitle],
-          @"count": @(assetsFetchResult.count),
-          @"type": fetchedAlbumType,
-          @"subType": @(obj.assetCollectionSubtype)
-        }];
-      }
-    };
-
+  ^(PHAssetCollection * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+    PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType fromTime:0 toTime:0];
+    // Enumerate assets within the collection
+    PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset
+                                                         fetchAssetsInAssetCollection:obj
+                                                         options:assetFetchOptions];
+    //리턴형태
+    if (assetsFetchResult.count > 0) {
+      [result addObject:@{
+        @"title": [obj localizedTitle],
+        @"count": @(assetsFetchResult.count),
+        @"type": fetchedAlbumType,
+        @"subType": @(obj.assetCollectionSubtype)
+      }];
+    }
+  };
+  
   PHFetchOptions* options = [[PHFetchOptions alloc] init];
   //album 받아오기
   if ([albumType isEqualToString:@"Album"] || [albumType isEqualToString:@"All"]) {
@@ -257,7 +257,7 @@ RCT_EXPORT_METHOD(getAlbums:(NSDictionary *)params
                                                         options:options];
     [assets enumerateObjectsUsingBlock:convertAsset];
   }
-
+  
   resolve(result);
 }
 
@@ -292,7 +292,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
                   reject:(RCTPromiseRejectBlock)reject)
 {
   checkPhotoLibraryConfig();
-
+  
   NSUInteger const first = [RCTConvert NSInteger:params[@"first"]];
   NSString *const afterCursor = [RCTConvert NSString:params[@"after"]];
   NSString *const groupName = [RCTConvert NSString:params[@"groupName"]];
@@ -303,7 +303,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
   NSUInteger const toTime = [RCTConvert NSInteger:params[@"toTime"]];
   NSArray<NSString *> *const mimeTypes = [RCTConvert NSStringArray:params[@"mimeTypes"]];
   NSArray<NSString *> *const include = [RCTConvert NSStringArray:params[@"include"]];
-
+  
   BOOL __block includeFilename = [include indexOfObject:@"filename"] != NSNotFound;
   BOOL __block includeFileSize = [include indexOfObject:@"fileSize"] != NSNotFound;
   BOOL __block includeLocation = [include indexOfObject:@"location"] != NSNotFound;
@@ -333,7 +333,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
   
   BOOL __block stopCollections_;
   NSString __block *currentCollectionName;
-
+  
   requestPhotoLibraryAccess(reject, ^{
     void (^collectAsset)(PHAsset*, NSUInteger, BOOL*) = ^(PHAsset * _Nonnull asset, NSUInteger assetIdx, BOOL * _Nonnull stopAssets) {
       NSString *const uri = [NSString stringWithFormat:@"ph://%@", [asset localIdentifier]];
@@ -363,12 +363,12 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
           }
           return; // skip until we get to the first one
         }
-
-
+        
+        
         if ([mimeTypes count] > 0 && resource) {
           CFStringRef const uti = (__bridge CFStringRef _Nonnull)(resource.uniformTypeIdentifier);
           NSString *const mimeType = (NSString *)CFBridgingRelease(UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType));
-
+          
           BOOL __block mimeTypeFound = NO;
           [mimeTypes enumerateObjectsUsingBlock:^(NSString * _Nonnull mimeTypeFilter, NSUInteger idx, BOOL * _Nonnull stop) {
             if ([mimeType isEqualToString:mimeTypeFilter]) {
@@ -376,13 +376,13 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
               *stop = YES;
             }
           }];
-
+          
           if (!mimeTypeFound) {
             return;
           }
         }
       }
-
+      
       // If we've accumulated enough results to resolve a single promise
       if (first == assets.count) {
         *stopAssets = YES;
@@ -393,43 +393,43 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         resolvedPromise = YES;
         return;
       }
-
+      
       NSString *const assetMediaTypeLabel = (asset.mediaType == PHAssetMediaTypeVideo
-                                            ? @"video"
-                                            : (asset.mediaType == PHAssetMediaTypeImage
+                                             ? @"video"
+                                             : (asset.mediaType == PHAssetMediaTypeImage
                                                 ? @"image"
                                                 : (asset.mediaType == PHAssetMediaTypeAudio
-                                                  ? @"audio"
-                                                  : @"unknown")));
+                                                   ? @"audio"
+                                                   : @"unknown")));
       CLLocation *const loc = asset.location;
-
+      
       [assets addObject:@{
         @"node": @{
           @"type": assetMediaTypeLabel, // TODO: switch to mimeType?
           @"group_name": currentCollectionName,
           @"image": @{
-              @"uri": uri,
-              @"filename": (includeFilename && originalFilename ? originalFilename : [NSNull null]),
-              @"height": (includeImageSize ? @([asset pixelHeight]) : [NSNull null]),
-              @"width": (includeImageSize ? @([asset pixelWidth]) : [NSNull null]),
-              @"fileSize": (includeFileSize ? fileSize : [NSNull null]),
-              @"playableDuration": (includePlayableDuration && asset.mediaType != PHAssetMediaTypeImage
-                                    ? @([asset duration]) // fractional seconds
-                                    : [NSNull null]),
-              @"path": path
+            @"uri": uri,
+            @"filename": (includeFilename && originalFilename ? originalFilename : [NSNull null]),
+            @"height": (includeImageSize ? @([asset pixelHeight]) : [NSNull null]),
+            @"width": (includeImageSize ? @([asset pixelWidth]) : [NSNull null]),
+            @"fileSize": (includeFileSize ? fileSize : [NSNull null]),
+            @"playableDuration": (includePlayableDuration && asset.mediaType != PHAssetMediaTypeImage
+              ? @([asset duration]) // fractional seconds
+              : [NSNull null]),
+            @"path": path
           },
           @"timestamp": @(asset.creationDate.timeIntervalSince1970),
           @"location": (includeLocation && loc ? @{
-              @"latitude": @(loc.coordinate.latitude),
-              @"longitude": @(loc.coordinate.longitude),
-              @"altitude": @(loc.altitude),
-              @"heading": @(loc.course),
-              @"speed": @(loc.speed), // speed in m/s
-            } : [NSNull null])
-          }
+            @"latitude": @(loc.coordinate.latitude),
+            @"longitude": @(loc.coordinate.longitude),
+            @"altitude": @(loc.altitude),
+            @"heading": @(loc.course),
+            @"speed": @(loc.speed), // speed in m/s
+          } : [NSNull null])
+        }
       }];
     };
-
+    
     if ([groupTypes isEqualToString:@"all"]) {
       PHFetchResult <PHAsset *> *const assetFetchResult = [PHAsset fetchAssetsWithOptions: assetFetchOptions];
       currentCollectionName = @"All Photos";
@@ -439,15 +439,15 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
       if ([groupTypes isEqualToString:@"smartalbum"]) {
         assetCollectionFetchResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:subType options:nil];
         [assetCollectionFetchResult enumerateObjectsUsingBlock:^(PHAssetCollection * _Nonnull assetCollection, NSUInteger collectionIdx, BOOL * _Nonnull stopCollections) {
-            PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:assetCollection options:assetFetchOptions];
-            currentCollectionName = [assetCollection localizedTitle];
-            [assetsFetchResult enumerateObjectsUsingBlock:collectAsset];
-        
+          PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:assetCollection options:assetFetchOptions];
+          currentCollectionName = [assetCollection localizedTitle];
+          [assetsFetchResult enumerateObjectsUsingBlock:collectAsset];
+          
           *stopCollections = stopCollections_;
         }];
       } else {
         PHAssetCollectionSubtype const collectionSubtype = [RCTConvert PHAssetCollectionSubtype:groupTypes];
-
+        
         // Filter collection name ("group")
         PHFetchOptions *const collectionFetchOptions = [PHFetchOptions new];
         collectionFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"endDate" ascending:NO]];
@@ -456,7 +456,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         }
         assetCollectionFetchResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum subtype:collectionSubtype options:collectionFetchOptions];
         [assetCollectionFetchResult enumerateObjectsUsingBlock:^(PHAssetCollection * _Nonnull assetCollection, NSUInteger collectionIdx, BOOL * _Nonnull stopCollections) {
-            // Enumerate assets within the collection
+          // Enumerate assets within the collection
           PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:assetCollection options:assetFetchOptions];
           currentCollectionName = [assetCollection localizedTitle];
           [assetsFetchResult enumerateObjectsUsingBlock:collectAsset];
@@ -464,7 +464,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         }];
       } // else of "if ([groupTypes isEqualToString:@"all"])"
     }
-
+    
     // If we get this far and haven't resolved the promise yet, we reached the end of the list of photos
     if (!resolvedPromise) {
       hasNextPage = NO;
@@ -484,13 +484,13 @@ RCT_EXPORT_METHOD(deletePhotos:(NSArray<NSString *>*)assets
   for (NSString *asset in assets) {
     [convertedAssets addObject: [asset stringByReplacingOccurrencesOfString:@"ph://" withString:@""]];
   }
-
+  
   [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
-      PHFetchResult<PHAsset *> *fetched =
-        [PHAsset fetchAssetsWithLocalIdentifiers:convertedAssets options:nil];
-      [PHAssetChangeRequest deleteAssets:fetched];
-    }
-  completionHandler:^(BOOL success, NSError *error) {
+    PHFetchResult<PHAsset *> *fetched =
+    [PHAsset fetchAssetsWithLocalIdentifiers:convertedAssets options:nil];
+    [PHAssetChangeRequest deleteAssets:fetched];
+  }
+                                    completionHandler:^(BOOL success, NSError *error) {
     if (success == YES) {
       resolve(@(success));
     }
@@ -505,119 +505,129 @@ RCT_EXPORT_METHOD(deletePhotos:(NSArray<NSString *>*)assets
 ///options로 인자 받는 방식으로 변경 예정. 이미지를 정해진 크기로 변환한다. 세로 기준으로 파일 사이즈를 줄인다.
 ///현재는 cameraroll에서 리턴받는 ph://{local identifier} 주소로만 동작한다.
 ///quality는 1.0~0.0
-//RCT_EXPORT_METHOD(compressImage:(NSString* _Nonnull)uri
 RCT_EXPORT_METHOD(compressImage:(NSDictionary * _Nonnull)params
-//                  compressWidth:(NSNumber* _Nonnull)width
-//                  compressHeight:(NSNumber* _Nonnull)height
-//                  compressionQuality:(NSNumber* _Nonnull)quality
                   resolver:(RCTPromiseResolveBlock) resolve
                   rejecter:(RCTPromiseRejectBlock) reject){
-NSArray<NSString *>* imageUris = [params objectForKey:@"imageFiles"]?[RCTConvert NSArray:[params objectForKey:@"imageFiles"]]:@[];
-CGFloat const quality = [params objectForKey:@"quality"]?[RCTConvert CGFloat:[params objectForKey:@"quality"]]:1;
-CGFloat const maxHeight = [params objectForKey:@"maxHeight"]?[RCTConvert CGFloat:[params objectForKey:@"maxHeight"]]:0;
-CGFloat const maxWidth = [params objectForKey:@"maxWidth"]?[RCTConvert CGFloat:[params objectForKey:@"maxWidth"]]:0;
-NSString *const mimeType = [params objectForKey:@"mimeType"]?[RCTConvert NSString:[params objectForKey:@"mimeType"]]:@"jpg";
+  NSArray<NSString *>* imageUris = [params objectForKey:@"imageFiles"] ? [RCTConvert NSArray:[params objectForKey:@"imageFiles"]]:@[];
+  CGFloat const quality = [params objectForKey:@"quality"] ? [RCTConvert CGFloat:[params objectForKey:@"quality"]]:1;
+  CGFloat const maxHeight = [params objectForKey:@"maxHeight"] ? [RCTConvert CGFloat:[params objectForKey:@"maxHeight"]]:0;
+  CGFloat const maxWidth = [params objectForKey:@"maxWidth"] ? [RCTConvert CGFloat:[params objectForKey:@"maxWidth"]]:0;
+  NSString *const mimeType = [params objectForKey:@"mimeType"] ? [RCTConvert NSString:[params objectForKey:@"mimeType"]]:@"jpg";
   
+  //이후 reject 여부 체크에서 errCode length로 판별하므로 빈 스트링 넣어줌
+  __block NSString* errCode = @"";
+  __block NSString* errMsg;
   
-  //일단 ph로 시작하는 주소만 받게 해 둠
-//  if ([uri containsString:@"ph://"] == false) {
-//    reject(@"Invalid image uri format.", @"Correct format is 'ph://{local identifier}'", nil);
-//    return;
-//  }
-  
-__block CGFloat oldWidth = 0;
-__block CGFloat oldHeight = 0;
-__block CGFloat newWidth = 0;
-__block CGFloat newHeight = 0;
-__block NSDictionary * result;
-__block NSMutableArray<NSDictionary *>* assets = [NSMutableArray array];
-//프로퍼티에 저장하지 않는 방법 강구
-//self.resolve = resolve;
-//self.reject = reject;
-  
-
-dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),^{
-  [imageUris enumerateObjectsUsingBlock:^(NSString * _Nonnull uri, NSUInteger idx, BOOL * _Nonnull stop) {
-  //camera roll에서 반환하는 uri는 ph:// + (localIdentifier) 라서 5번째 인덱스부터
-  PHFetchResult<PHAsset *> *asset = [PHAsset fetchAssetsWithLocalIdentifiers:@[[uri substringFromIndex:@"ph://".length]] options:nil];
-  
-  if(asset == nil || asset.count == 0) {
-    self.reject(@"Image fetch result error", @"Image fetch result is nil.", nil);
-    return;
-  } else if(asset.firstObject == nil) {
-    self.reject(@"Nil error", @"Image is nil", nil);
-    return;
-  }
-  
-  oldWidth = asset.firstObject.pixelWidth;
-  oldHeight = asset.firstObject.pixelHeight;
-  
-  if(maxWidth == 0 || maxHeight == 0){
-    newHeight = oldHeight;
-    newWidth = oldWidth;
-  }else{
-    if(maxWidth < oldWidth){
-      newHeight = (int)((maxWidth / oldWidth) * oldHeight);
-      newWidth = maxWidth;
-    }
-    
-    if(maxHeight < oldHeight){
-      newWidth = (int)((maxHeight / oldHeight)*oldWidth);
-      newHeight = maxHeight;
-    }
-  }
-    
-  
-  
-  CGSize newSize = CGSizeMake(newWidth, newHeight);
-  PHImageRequestOptions* options = [PHImageRequestOptions new];
-  options.synchronous = true;
-  [[PHImageManager defaultManager] requestImageForAsset:asset.firstObject
-                                             targetSize:newSize
-                                            contentMode:PHImageContentModeAspectFit
-                                                options:options
-                                          resultHandler:^(UIImage * _Nullable img, NSDictionary * _Nullable info) {
-    if(img == nil){
-      reject(@"nil error", @"image result is nil", nil);
+  //enumerateObjectsUsingBlocks가 빈 문자열을 대상으로 순환을 시도할 때 에러가 나므로 위에서 잡아주어야 함
+  NSUInteger nUris = imageUris.count;
+  for (int i = 0; i < nUris; ++i){
+    if(imageUris[i].length == 0) {
+      errCode = @"String empty";
+      errMsg = @"Uri is an empty string";
+      reject(errCode, errMsg, nil);
       return;
     }
-    
-    //압축된 데이터
-    NSData *imageData = [NSData data];
-    if([mimeType.lowercaseString isEqualToString:@"jpg"]){
-      imageData = UIImageJPEGRepresentation(img, quality);
-    }
-    if([mimeType.lowercaseString isEqualToString:@"png"]){
-      imageData = UIImagePNGRepresentation(img);
-    }
-    
-    NSString* savedPath = [self createTempImage:imageData];
-
-//    if (savedPath == nil) {
-//      reject(@"Fail to save", @"Failed to save compressed image", nil);
-//      return;
-//    } else {
-//      resolve(savedPath);
-//    }
-    if(savedPath == nil){
-      savedPath=@"Fail to Save Image";
-    }
-    NSDictionary* imgRes = @{
-      @"uri":savedPath,
-      @"fileSize":@([imageData length]),
-      @"fileName":savedPath,
-      @"type":mimeType,
-      @"width":@(newWidth),
-      @"height":@(newHeight),
-    };
-    [assets addObject:imgRes];
-    
-    }];
-  }];
-  result = @{@"assets":assets};
-  resolve(result);
-});
+  }
   
+  __block CGFloat oldWidth = 0;
+  __block CGFloat oldHeight = 0;
+  __block CGFloat newWidth = 0;
+  __block CGFloat newHeight = 0;
+  __block NSDictionary * result;
+  __block NSMutableArray<NSDictionary *>* assets = [NSMutableArray array];
+  
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),^{
+    [imageUris enumerateObjectsUsingBlock:^(NSString * _Nonnull uri, NSUInteger idx, BOOL * _Nonnull stop) {
+      if (![uri hasPrefix:@"ph://"]) {
+        errCode = @"Uri format error";
+        errMsg = @"Uri format doesn't fit with photoKit ('ph://')";
+        *stop = YES;
+        return;
+      }
+      
+      PHFetchResult<PHAsset *> *asset = [PHAsset fetchAssetsWithLocalIdentifiers:@[[uri substringFromIndex:@"ph://".length]] options:nil];
+      
+      if(asset == nil || asset.count == 0) {
+        errCode = @"Nil error";
+        errMsg = @"Image fetch result is nil";
+        *stop = YES;
+        return;
+      } else if(asset.firstObject == nil) {
+        errMsg = @"Image fetch result is nil";
+        *stop = YES;
+        return;
+      }
+      
+      oldWidth = asset.firstObject.pixelWidth;
+      oldHeight = asset.firstObject.pixelHeight;
+      
+      if(maxWidth == 0 || maxHeight == 0){
+        newHeight = oldHeight;
+        newWidth = oldWidth;
+      } else {
+        if(maxWidth < oldWidth){
+          newHeight = (int)((maxWidth / oldWidth) * oldHeight);
+          newWidth = maxWidth;
+        }
+        
+        if(maxHeight < oldHeight){
+          newWidth = (int)((maxHeight / oldHeight)*oldWidth);
+          newHeight = maxHeight;
+        }
+      }
+      
+      CGSize newSize = CGSizeMake(newWidth, newHeight);
+      PHImageRequestOptions* options = [PHImageRequestOptions new];
+      options.synchronous = true;
+      [[PHImageManager defaultManager] requestImageForAsset:asset.firstObject
+                                                 targetSize:newSize
+                                                contentMode:PHImageContentModeAspectFit
+                                                    options:options
+                                              resultHandler:^(UIImage * _Nullable img, NSDictionary * _Nullable info) {
+        if(img == nil){
+          errCode = @"Nil error";
+          errMsg = @"Image result is nil";
+          *stop = YES;
+          return;
+        }
+        
+        //압축된 데이터
+        NSData *imageData = [NSData data];
+        if([mimeType.lowercaseString isEqualToString:@"jpg"]){
+          imageData = UIImageJPEGRepresentation(img, quality);
+        } else if([mimeType.lowercaseString isEqualToString:@"png"]){
+          imageData = UIImagePNGRepresentation(img);
+        }
+        
+        NSString* savedPath = [self createTempImage:imageData mimeType:mimeType];
+        if(savedPath == nil){
+          errCode = @"Image save error";
+          errMsg = @"Fail to save image";
+          *stop = YES;
+          return;
+        }
+        
+        NSDictionary* imgRes = @{
+          @"uri":savedPath,
+          @"fileSize":@([imageData length]),
+          @"fileName":savedPath,
+          @"type":mimeType,
+          @"width":@(newWidth),
+          @"height":@(newHeight),
+        };
+        [assets addObject:imgRes];
+      }];
+    }];
+    
+    if(assets == nil || assets.count == 0) {
+      reject(errCode, errMsg, nil);
+    } else if (errCode.length != 0) {
+      reject(errCode, errMsg, nil);
+    } else {
+      result = @{@"assets":assets};
+      resolve(result);
+    }
+  });
 }
 
 //#MARK: @RCT savaeImage
@@ -625,48 +635,45 @@ dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),^{
 RCT_EXPORT_METHOD(saveImage:(NSString*) uri
                   resolver:(RCTPromiseResolveBlock) resolve
                   rejecter:(RCTPromiseRejectBlock) reject){
-//  NSLog(@"saveImage native");
   if(uri == nil) {
     reject(@"URI is nil", nil, nil);
     return;
   }
   //!!저장 뒤 메타데이터는 확인하지 않았으므로 아직 확실하지 않은 상태!!
   //!
-  //프로퍼티에 저장하지 않는 방법 강구
-  self.resolve = resolve;
-  self.reject = reject;
   __block NSData *imageData = nil;
   
   void (^save)(void) = ^void() {
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
       //여기서 루프 돌려서 큐 잡아두는 테스트 함
-//      for(int i = 0; i < 100000; ++i){
-//        NSLog(@"cur i: %d", i);
-//      }
+      //      for(int i = 0; i < 100000; ++i){
+      //        NSLog(@"cur i: %d", i);
+      //      }
       
       if ([PHAssetCreationRequest class]) {
-          [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
-              [[PHAssetCreationRequest creationRequestForAsset] addResourceWithType:PHAssetResourceTypePhoto
-                                                                               data:imageData options:nil];
-          } completionHandler:^(BOOL success, NSError * _Nullable error) {
-              if (success) {
-                self.resolve(nil);
-              } else {
-                self.reject(@"Fail to save image", error.localizedDescription, error);
-              }
-          }];
+        [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+          [[PHAssetCreationRequest creationRequestForAsset] addResourceWithType:PHAssetResourceTypePhoto
+                                                                           data:imageData options:nil];
+        } completionHandler:^(BOOL success, NSError * _Nullable error) {
+          if (success) {
+            resolve(nil);
+          } else {
+            reject(@"Fail to save image", error.localizedDescription, error);
+          }
+        }];
       } else {
         //UIImageWriteToSavedPhotosAlbum도 사용 가능하지만 그러면 메타데이터가 전부 날아가기 때문에 임시로 저장한 뒤 카메라 앨범에 저장한다
-        NSString* savedPath = [self createTempImage:imageData];
+        NSString* savedPath = [self createTempImage:imageData mimeType:NULL];
         [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
           [PHAssetChangeRequest creationRequestForAssetFromImageAtFileURL:[NSURL URLWithString:savedPath]];
         } completionHandler:^(BOOL success, NSError * _Nullable error) {
-            if (success) {
-              self.resolve(nil);
-            } else {
-              self.reject(@"Fail to save image", error.localizedDescription, error);
-            }
-            [[NSFileManager defaultManager] removeItemAtURL:[NSURL URLWithString:savedPath] error:nil];
+          if (success) {
+            resolve(nil);
+          } else {
+            reject(@"Fail to save image", error.localizedDescription, error);
+          }
+          //임시로 저장했던 파일은 삭제하고 함수 종료
+          [[NSFileManager defaultManager] removeItemAtURL:[NSURL URLWithString:savedPath] error:nil];
         }];
       }
     });
@@ -677,10 +684,10 @@ RCT_EXPORT_METHOD(saveImage:(NSString*) uri
     PHFetchResult<PHAsset *> *asset = [PHAsset fetchAssetsWithLocalIdentifiers:@[[uri substringFromIndex:5]] options:nil];
     
     if(asset == nil || asset.count == 0) {
-      self.reject(@"Image fetch result is nil.", nil, nil);
+      reject(@"Image fetch result is nil.", nil, nil);
       return;
     } else if(asset.firstObject == nil) {
-      self.reject(@"Image is nil", nil, nil);
+      reject(@"Image is nil", nil, nil);
       return;
     }
     
@@ -698,9 +705,9 @@ RCT_EXPORT_METHOD(saveImage:(NSString*) uri
       [PHAssetCreationRequest creationRequestForAssetFromImageAtFileURL:[NSURL URLWithString:uri]];
     } completionHandler:^(BOOL success, NSError * _Nullable error) {
       if(success){
-        self.resolve(nil);
+        resolve(nil);
       } else {
-        self.reject(@"Fail to save image", error.localizedDescription, error);
+        reject(@"Fail to save image", error.localizedDescription, error);
       }
     }];
   }
@@ -717,48 +724,49 @@ static void checkPhotoLibraryConfig()
 }
 
 //#MARK: @createTempImage
-- (NSString*) createTempImage:(NSData*)data {
-    NSString *tmpDirFullPath = [self getTmpDirectory];
-    NSString *filePath = [tmpDirFullPath stringByAppendingString:[[NSUUID UUID] UUIDString]];
-    filePath = [filePath stringByAppendingString:@".jpg"];
-    
-    BOOL status = [data writeToFile:filePath atomically:YES];
-    if (!status) {
-        return nil;
-    }
-    
-    return filePath;
+- (NSString*) createTempImage:(NSData*)data
+                     mimeType:(NSString* _Nullable )mimeType{
+  NSString *tmpDirFullPath = [self getTmpDirectory];
+  NSString *filePath = [tmpDirFullPath stringByAppendingString:[[NSUUID UUID] UUIDString]];
+  NSString* type = (mimeType != NULL || mimeType.length != 0) ? mimeType:@"jpg";
+  filePath = [filePath stringByAppendingString:[NSString stringWithFormat:@".%@", type]];
+  
+  BOOL status = [data writeToFile:filePath atomically:YES];
+  if (!status) {
+    return nil;
+  }
+  
+  return filePath;
 }
-
 
 //#MARK: @getTmpDirectory
 - (NSString*) getTmpDirectory {
   NSString *tmpFullPath = [NSTemporaryDirectory() stringByAppendingString:tempDirectoryPath];
-    
-    BOOL isDir;
-    BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:tmpFullPath isDirectory:&isDir];
-    if (!exists) {
-        [[NSFileManager defaultManager] createDirectoryAtPath: tmpFullPath
-                                  withIntermediateDirectories:YES attributes:nil error:nil];
-    }
-    
-    return tmpFullPath;
+  
+  BOOL isDir;
+  BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:tmpFullPath isDirectory:&isDir];
+  if (!exists) {
+    [[NSFileManager defaultManager] createDirectoryAtPath: tmpFullPath
+                              withIntermediateDirectories:YES attributes:nil error:nil];
+  }
+  
+  return tmpFullPath;
 }
 
 //#MARK: @cleanTmpdirectory
 - (BOOL)cleanTmpDirectory {
-    NSString* tmpDirectoryPath = [self getTmpDirectory];
-    NSArray* tmpDirectory = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:tmpDirectoryPath error:nil];
+  NSString* tmpDirectoryPath = [self getTmpDirectory];
+  NSArray* tmpDirectory = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:tmpDirectoryPath error:nil];
+  
+  for (NSString *file in tmpDirectory) {
+    BOOL deleted = [[NSFileManager defaultManager] removeItemAtPath:[NSString stringWithFormat:@"%@%@", tmpDirectoryPath, file] error:nil];
     
-    for (NSString *file in tmpDirectory) {
-        BOOL deleted = [[NSFileManager defaultManager] removeItemAtPath:[NSString stringWithFormat:@"%@%@", tmpDirectoryPath, file] error:nil];
-        
-        if (!deleted) {
-            return false;
-        }
+    if (!deleted) {
+      return false;
     }
-    
-    return true;
+  }
+  
+  return true;
 }
 
 ////#MARK: @RCT cleanSingle
@@ -778,11 +786,11 @@ static void checkPhotoLibraryConfig()
 RCT_REMAP_METHOD(clean,
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-    if (![self cleanTmpDirectory]) {
-        reject(@"ERROR_CLEANUP_ERROR_KEY", @"ERROR_CLEANUP_ERROR_MSG", nil);
-    } else {
-        resolve(nil);
-    }
+  if (![self cleanTmpDirectory]) {
+    reject(@"Fail to clean", @"Fail to clean temp directory", nil);
+  } else {
+    resolve(nil);
+  }
 }
 
 @end

--- a/src/module/CameraRoll.d.ts
+++ b/src/module/CameraRoll.d.ts
@@ -8,7 +8,7 @@
  * 
  */
  'use strict';
- import { Platform, NativeModules } from 'react-native';
+ import { Platform, NativeModules, Image } from 'react-native';
  
  const RNCCameraRoll  = Platform.OS=='ios'?NativeModules.RNCCameraRoll:NativeModules.PhotoListModule;
  
@@ -134,6 +134,7 @@
      end_cursor?: string,
    },
  };
+
  export type SaveToCameraRollOptions = {
    type?: 'photo' | 'video' | 'auto',
    album?: string,
@@ -150,6 +151,36 @@
    subType: string,
    count: number,
  };
+
+ export type CompressionParams = {
+   /**
+    * 압축할 이미지 파일의 uri.
+    * 포맷은 ph://{local identifier}이다.
+    * cameraRoll에서 반환하는 이미지 경로라면 문제없이 작동함
+    */
+  imageFiles: string[],
+
+  /**
+   * 압축 퀄리티. 0 ~ 1 사이의 실수. 미지정 시 디폴트 1
+   */
+  quality?: number,
+
+  /**
+   * 이미지 압축 시 최대 세로 길이. 미지정 시 디폴트 0
+   */
+  maxHeight?: number,
+
+  /**
+   * 이미지 압축 시 최대 가로 길이. 미지정 시 0
+   */
+  maxWidth?: number,
+
+  /**
+   * 이미지 형식. jpg, png만 가능
+   * 지정하지 않을 경우 jpg
+   */
+  mimeType?: string,
+};
  
  /**
   * `CameraRoll` provides access to the local camera roll or photo library.
@@ -163,16 +194,11 @@
  
    /**
     * uri 리스트를 넘겨주고 해당 리스트의 uri에 해당하는 파일을 압축
-    * @param uri 
-    * @param compressWidth 
-    * @param compressHeight 
-    * @param compressionQuality 
+    * @param CompressionParams CameraRoll.d.ts 참조
     * @returns 
     */
-   static compressImage(uri: string, 
-     compressWidth: number,  compressHeight: number, compressionQuality: number): Promise<string>{
- 
-     return RNCCameraRoll.compressImage(uri, compressWidth, compressHeight, compressionQuality);
+   static compressImage(params: CompressionParams): Promise<Image[]>{
+    return RNCCameraRoll.compressImage(params);
    }
 
   static saveImage(uri: string): Promise<void>{


### PR DESCRIPTION
[하늘] Camera Roll Ios 모듈 compress 함수 파라미터 NSDictionary (type CompressionParams)로 변경, compress 및 save 함수 png 이미지 대응하도록 변경, 이외 오류처리 추가


*수정 사항:  compress type CompressionParams로 파라미터 변경 / compress 및 save 함수에 png 대응 추가 / deprecated될 함수 대응 추가
*수정 결과: 압축, 저장 잘 됨
*수정 파일: 1) RNCCameraRollManager.h 
2) RNCCameraRollManager.m :  - compressImage: resolver: rejecter  (파라미터 및 리턴값 변경, 에러 * png * deprecated 함수 대응 추가)
- saveImage: resolver: rejecter (png * deprecated 함수 대응 추가)
- createTempImage: mimeType: (mimeType 대응 추가)
3) CameraRoll.d.ts: - line 155 type CompressionParams 추가 (compressImage 변수)
- line 200 static compressImage (변수 변경)