### PR TITLE
[재현] 오류 수정, 피드 하단탭 다시 클릭시 위로 스크롤 구현 실패

### DIFF
--- a/src/component/organism/comment/AlarmCommentList.js
+++ b/src/component/organism/comment/AlarmCommentList.js
@@ -14,6 +14,7 @@ import {GRAY10, GRAY20, GRAY30} from 'Root/config/color';
 import {useKeyboardBottom} from 'Molecules/input/usekeyboardbottom';
 import {useNavigation} from '@react-navigation/core';
 import {deleteComment} from 'Root/api/commentapi';
+import {SafeAreaView} from 'react-native-safe-area-context';
 
 const AlarmCommentList = props => {
 	// console.log('AlarmCommentList props', props.route.params);
@@ -52,6 +53,7 @@ const AlarmCommentList = props => {
 	// 	fetchData();
 	// }, [comments]);
 	const fetchData = () => {
+		console.log('getCommentList by ', props.route.params.feedobject._id);
 		getCommentListByFeedId(
 			{
 				feedobject_id: props.route.params.feedobject._id,
@@ -59,7 +61,7 @@ const AlarmCommentList = props => {
 				// login_userobject_id: userGlobalObject.userInfo._id,
 			},
 			comments => {
-				setComments(comments.msg);
+				setComments(comments.msg.filter(e => e.comment_is_delete != true));
 				setCommentsLoaded(true);
 				console.log('comments', comments);
 			},
@@ -318,6 +320,7 @@ const AlarmCommentList = props => {
 		return (
 			<View>
 				<FeedContent data={props.route.params.feedobject} showAllContents={true} />
+
 				<View style={[style.replyCountContainer, {alignSelf: 'center', alignItems: 'flex-start'}]}>
 					<Text style={[txt.noto24, {color: GRAY10}]}> 댓글 {comments.length}개</Text>
 				</View>
@@ -350,11 +353,13 @@ const AlarmCommentList = props => {
 	// const components = [header(), commentBox()];
 	return (
 		<View style={[login_style.wrp_main, feedCommentList.container]}>
+			<Header />
+
 			<FlatList
 				data={comments}
 				renderItem={renderItem}
 				listKey={({item, index}) => index}
-				ListHeaderComponent={Header}
+				// ListHeaderComponent={Header}
 				ListFooterComponent={<View style={{height: heightReply + keyboardY}}></View>}
 				// ListFooterComponent={Bottom}
 				ref={flatListRef}

--- a/src/component/organism/feed/FeedContent.js
+++ b/src/component/organism/feed/FeedContent.js
@@ -503,6 +503,8 @@ export default FeedContent = props => {
 			return {};
 		} else if (isCommentList) {
 			return {};
+		} else if (route.name == 'AlarmCommentList') {
+			return {};
 		} else {
 			let lines = getLinesOfString(feed_content, Platform.OS == 'android' ? 48 : 50);
 			return {

--- a/src/component/templete/feed/FeedList.js
+++ b/src/component/templete/feed/FeedList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {StyleSheet, View, FlatList, RefreshControl, Platform, NativeModules, Text, TextInput, Dimensions, PixelRatio} from 'react-native';
-import {WHITE} from 'Root/config/color';
+import {GRAY10, GRAY20, WHITE} from 'Root/config/color';
 import {Write94, Camera54} from 'Atom/icon';
 import Feed from 'Organism/feed/Feed';
 import {getSuggestFeedList} from 'Root/api/feedapi';
@@ -14,6 +14,7 @@ import {getStringLength, getLinesOfString} from 'Root/util/stringutil';
 import {GRAY30} from 'Root/config/color';
 import {txt} from 'Root/config/textstyle';
 import {TouchableWithoutFeedback} from 'react-native-gesture-handler';
+import {useScrollToTop} from '@react-navigation/native';
 export default FeedList = ({route, navigation}) => {
 	const [feedList, setFeedList] = React.useState([]);
 	const [refreshing, setRefreshing] = React.useState(false);
@@ -240,6 +241,9 @@ export default FeedList = ({route, navigation}) => {
 			userGlobalObject.t = e.nativeEvent.contentOffset;
 		}
 	};
+	const moveToTop = () => {
+		useScrollToTop(flatlist);
+	};
 
 	const movetoCamera = () => {
 		// NativeModules.CalendarModule.createCalendarEvent('네이티브 테스트','스터디카페')
@@ -263,7 +267,7 @@ export default FeedList = ({route, navigation}) => {
 	const [testTx, setTx] = React.useState('한');
 	const [code, setCode] = React.useState(62);
 	return (
-		<View style={(login_style.wrp_main, {flex: 1, backgroundColor: WHITE})}>
+		<View style={(login_style.wrp_main, {flex: 1, backgroundColor: WHITE, borderTopWidth: 2 * DP, borderTopColor: GRAY30})}>
 			<FlatList
 				data={feedList}
 				renderItem={renderItem}

--- a/src/component/templete/list/AlarmList.js
+++ b/src/component/templete/list/AlarmList.js
@@ -15,7 +15,7 @@ import {CommonActions, useNavigationState} from '@react-navigation/native';
 import {useNavigation} from '@react-navigation/native';
 import {getFeedDetailById} from 'Root/api/feedapi';
 import {getUserVolunteerActivityList, getVolunteerActivityById} from 'Root/api/volunteerapi';
-import {getApplyDetailById} from 'Root/api/protectapi';
+import {getApplyDetailById, getProtectRequestByProtectRequestId} from 'Root/api/protectapi';
 import {getAppliesRecord} from 'Root/api/protectapi';
 import {getCommunityByObjectId} from 'Root/api/community';
 
@@ -72,7 +72,7 @@ const AlarmList = props => {
 		);
 	};
 	const onLabelClick = data => {
-		console.log(data.target_object_type, data);
+		console.log('aa', data.target_object_type, data);
 		let navState = props.navigation.getState();
 		// console.log('navState', navState);
 
@@ -206,6 +206,17 @@ const AlarmList = props => {
 					},
 				);
 				break;
+			case 'ProtectRequestObject':
+				getProtectRequestByProtectRequestId(
+					{protect_request_object_id: data.target_object},
+					result => {
+						console.log('result', result.msg);
+						navigation.push('ProtectCommentList', {protectObject: result.msg, showKeyboard: false});
+					},
+					err => {
+						console.log('getProtectRequestByProtectRequestId err', err);
+					},
+				);
 		}
 	};
 

--- a/src/component/templete/pet/AssignPetProfileImage.js
+++ b/src/component/templete/pet/AssignPetProfileImage.js
@@ -1,7 +1,7 @@
 import {useNavigation} from '@react-navigation/core';
 import React from 'react';
 import {Text, View, TouchableOpacity, ScrollView, Image, TouchableWithoutFeedback, KeyboardAvoidingView} from 'react-native';
-import {APRI10, GRAY10, GRAY20} from 'Root/config/color';
+import {APRI10, GRAY10, GRAY20, GRAY30} from 'Root/config/color';
 import DP from 'Root/config/dp';
 import {txt} from 'Root/config/textstyle';
 import {AVAILABLE_NICK, DEFAULT_PROFILE, NICKNAME_FORM} from 'Root/i18n/msg';
@@ -199,7 +199,9 @@ export default AssignPetProfileImage = ({route}) => {
 					/>
 				</View>
 				<View style={[temp_style.textMsg_assignPetProfileImage, assignPetProfileImage_style.textMsg]}>
-					<Text style={[txt.noto24, {color: GRAY10}]}>반려동물 프로필의 대표 이미지가 될 사진과 이름을 알려주세요.</Text>
+					<Text style={[txt.noto24, {color: GRAY10}]}>
+						{`반려동물 프로필의 대표 이미지가 될 사진과 이름을 알려주세요.\n반려동물의 이름은 수정이 불가합니다.`}
+					</Text>
 				</View>
 
 				{/* (M)ProfileImageSelect */}

--- a/src/component/templete/user/SettingAccount.js
+++ b/src/component/templete/user/SettingAccount.js
@@ -10,15 +10,23 @@ import Modal from 'Root/component/modal/Modal';
 export default SettingAccount = ({route}) => {
 	const navigation = useNavigation();
 	const logout = () => {
-		userLogout(
-			1,
-			e => {
-				console.log('e', e);
-				userGlobalObject.userInfo = {};
-				navigation.reset({routes: [{name: 'Login'}]});
-			},
-			err => {
-				console.log('err', err);
+		Modal.popTwoBtn(
+			'정말로 로그아웃 하시겠습니까?',
+			'아니오',
+			'네',
+			() => Modal.close(),
+			() => {
+				userLogout(
+					1,
+					e => {
+						console.log('e', e);
+						userGlobalObject.userInfo = {};
+						navigation.reset({routes: [{name: 'Login'}]});
+					},
+					err => {
+						console.log('err', err);
+					},
+				);
 			},
 		);
 	};

--- a/src/navigation/maintab/BottomTab.js
+++ b/src/navigation/maintab/BottomTab.js
@@ -17,6 +17,7 @@ import {
 	ProfileDefaultImg,
 } from 'Atom/icon';
 import userGlobalObject from 'Root/config/userGlobalObject';
+import {useScrollToTop} from '@react-navigation/native';
 
 export default function BottomTab({state, descriptors, navigation}) {
 	// console.log('바텀탭 유저 글로벌',userGlobalObject);
@@ -25,7 +26,7 @@ export default function BottomTab({state, descriptors, navigation}) {
 	const iconsFocused = [<FeedTabFilled />, <AnimalSavingTabFilled />, <CommunityTabFilled />, <MyTabFilled />];
 
 	const iconlayout = [tab.tab_feed, tab.tab_animal_saving, tab.tab_community, tab.tab_my];
-
+	const ref = React.useRef();
 	let currentIndex = null;
 	if (focusedOptions.tabBarVisible === false) {
 		return null;
@@ -69,7 +70,10 @@ export default function BottomTab({state, descriptors, navigation}) {
 								navigation.navigate({name: 'Login', merge: true});
 							});
 						} else {
-							console.log('tabP');
+							console.log('tabP', route);
+							if (route.name == 'FEED') {
+								// navigation.navigate(name: "FeedList");
+							}
 							const event = navigation.emit({
 								type: 'tabPress',
 								target: route.key,

--- a/src/navigation/route/main_tab/feed_stack/FeedStackNavigation.js
+++ b/src/navigation/route/main_tab/feed_stack/FeedStackNavigation.js
@@ -20,6 +20,7 @@ import AlarmCommentList from 'Root/component/organism/comment/AlarmCommentList';
 
 import SetPetInformation from 'Root/component/templete/pet/SetPetInformation';
 import EditShelterInfo from 'Root/component/templete/shelter/EditShelterInfo';
+import ProtectCommentList from 'Root/component/templete/protection/ProtectCommentList';
 
 const FeedStack = createStackNavigator();
 
@@ -107,6 +108,7 @@ export default FeedStackNavigation = () => {
 				component={EditShelterInfo}
 				options={{header: props => <SimpleHeader {...props} />, title: '보호소 정보 수정'}}
 			/>
+			<FeedStack.Screen name="ProtectCommentList" component={ProtectCommentList} options={{header: props => <SimpleHeader {...props} />}} />
 		</FeedStack.Navigator>
 	);
 };


### PR DESCRIPTION
*수정 사항: 테스트시 오류와 미미한 점들을 수정하였습니다.
*수정 결과: 오류 수정은 잘되어가고있지만 피드 바텀탭 클릭시 위로 스크롤 하는 기능을 만드는 부분에서 막혔습니다. ㅠㅠ
*수정 파일: 
AlarmCommentList - 에러 수정 FeedCotent - 알림에서 이동 View 에러 수정
FeedList - 피드 위의 줄 생성
AlarmList - 없던 Navigation 추가 
AssignPetProfileImage - 문구 변경
SettingAccount - 로그아웃시 물어보는 모달 추가 
BottomTab - 피드에서 탭 클릭시 위로 이동 도입 실패

package.json 에 cameraroll 이 추가되었지만 커밋에 올리지 않았습니다. 