### PR TITLE
[하늘] ios camera module crop 기능 추가

### DIFF
--- a/IosModuleTest_App.js
+++ b/IosModuleTest_App.js
@@ -128,6 +128,29 @@ export default class App extends Component {
       });
   }
 
+  cropImage(){
+    CameraRoll.cropImage({
+      destWidth: 1100,
+      destHeight: 300,
+      offsetX: 500,
+      offsetY: 1000,
+      uri: this.state.image.uri
+    })
+    .then(r => {
+      this.setState({
+        image: {
+          uri: r.uri,
+          width: r.width,
+          height: r.height,
+        },
+        images: null,
+      });
+    })
+    .catch(err => {
+      console.log(err);
+    })
+  }
+
   cleanupImages() {
     CameraRoll.clean()
       .then(() => {
@@ -170,7 +193,7 @@ export default class App extends Component {
         </TouchableOpacity>
 
         <TouchableOpacity
-          onPress={() => this.getImage(3, 0)}
+          onPress={() => this.getImage(15, 14)}
           style={styles.button}>
           <Text style={styles.text}>getImage</Text>
         </TouchableOpacity>
@@ -190,8 +213,6 @@ export default class App extends Component {
             .catch(err => {
               console.log(err);
             });
-            //save queue 추가하고 대기 중 ui 변경되는지 테스트용도 (현재 save loop 주석처리힘)
-            // this.getImage(5, 4);
           }}
           style={styles.button}>
           <Text style={styles.text}>save selected Image</Text>
@@ -203,6 +224,14 @@ export default class App extends Component {
           }}
           style={styles.button}>
           <Text style={styles.text}>compress selected Image</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => {
+            this.cropImage();
+          }}
+          style={styles.button}>
+          <Text style={styles.text}>crop selected Image</Text>
         </TouchableOpacity>
 
         <TouchableOpacity

--- a/ios/anilog/RNCCameraRollManager.m
+++ b/ios/anilog/RNCCameraRollManager.m
@@ -766,6 +766,8 @@ static void checkPhotoLibraryConfig()
   
   return true;
 }
+
+//#MARK: @requestImageData
    /**
      ph://{local identifier} 형식의 uri에서 이미지를 가져오는 함수
     가져온 데이터를 받는 건 handler callback

--- a/ios/anilog/RNCCameraRollManager.m
+++ b/ios/anilog/RNCCameraRollManager.m
@@ -744,15 +744,18 @@ RCT_EXPORT_METHOD(cropImage:(NSDictionary* _Nonnull) params
     return;
   }
   
-  CGFloat const destWidth = [params objectForKey:@"destWidth"] ? [RCTConvert CGFloat:[params objectForKey:@"destWidth"]] : -1;
-  CGFloat const destHeight = [params objectForKey:@"destHeight"] ? [RCTConvert CGFloat:[params objectForKey:@"destHeight"]] : -1;
-  if(destWidth == -1 || destHeight == -1) {
+  CGFloat const destWidth = [params objectForKey:@"destWidth"] ? [RCTConvert CGFloat:[params objectForKey:@"destWidth"]] : 0;
+  CGFloat const destHeight = [params objectForKey:@"destHeight"] ? [RCTConvert CGFloat:[params objectForKey:@"destHeight"]] : 0;
+  if(destWidth <= 0 || destHeight <= 0) {
     reject(@"Mandatory parameter has no value", @"Mandatory parameter has no value", nil);
     return;
   }
   
   CGFloat const offsetX = [params objectForKey:@"offsetX"] ? [RCTConvert CGFloat:[params objectForKey:@"offsetX"]] : 0;
   CGFloat const offsetY = [params objectForKey:@"offsetY"] ? [RCTConvert CGFloat:[params objectForKey:@"offsetY"]] : 0;
+  
+  //현재 rotate 안 됨
+//  CGFloat const angle = [params objectForKey:@"angle"] ? [RCTConvert CGFloat:[params objectForKey:@"angle"]] : 0;
   BOOL const isCircular = [params objectForKey:@"isCircular"] ? [RCTConvert BOOL:[params objectForKey:@"isCircular"]] : NO;
   
   CGRect destRect = {
@@ -760,7 +763,6 @@ RCT_EXPORT_METHOD(cropImage:(NSDictionary* _Nonnull) params
     CGSizeMake(destWidth, destHeight)
   };
   
-  //현재 scale, angle 안 됨
   UIImage* targetImage = [UIImage imageWithData:imageData];
   UIImage* croppedImage = nil;
   
@@ -773,7 +775,9 @@ RCT_EXPORT_METHOD(cropImage:(NSDictionary* _Nonnull) params
   }
   
   //crop
+  //crop 자체가 scale과 비슷한 효과를 내므로 scale 삭제
   CGContextTranslateCTM(context, -destRect.origin.x, -destRect.origin.y);
+  
   [targetImage drawAtPoint:CGPointZero];
   croppedImage = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();

--- a/src/module/CameraRoll.d.ts
+++ b/src/module/CameraRoll.d.ts
@@ -181,6 +181,18 @@
    */
   mimeType?: string,
 };
+
+export type CropParams = {
+  uri: string,
+  destWidth: number,
+  destHeight: number,
+  destScaleX?: number, //default 1
+  destScaleY?: number, //default 1
+  offsetX?: number, //default 0
+  offsetY?: number, // default 0
+  angle?: number, //default 0
+  isCircular?: boolean,//deefault false
+}
  
  /**
   * `CameraRoll` provides access to the local camera roll or photo library.
@@ -199,6 +211,10 @@
     */
    static compressImage(params: CompressionParams): Promise<Image[]>{
     return RNCCameraRoll.compressImage(params);
+   }
+
+   static cropImage(params: CropParams): Promise<Image>{
+     return RNCCameraRoll.cropImage(params);
    }
 
   static saveImage(uri: string): Promise<void>{

--- a/src/module/CameraRoll.d.ts
+++ b/src/module/CameraRoll.d.ts
@@ -184,12 +184,10 @@
 
 export type CropParams = {
   uri: string,
-  destWidth: number,
-  destHeight: number,
-  destScaleX?: number, //default 1
-  destScaleY?: number, //default 1
-  offsetX?: number, //default 0
-  offsetY?: number, // default 0
+  destWidth: number, //uint
+  destHeight: number, //uint
+  offsetX?: number, //uint, default 0
+  offsetY?: number, // uint, default 0
   angle?: number, //default 0
   isCircular?: boolean,//deefault false
 }


### PR DESCRIPTION
*수정 사항: 
1) camera module ios save 함수 변경
                   - 내부에서 PHFetch를 이용해 이미지 데이터를 받아오는 부분을 별도 함수로 빼냈습니다.
             
2) camera module ios crop 함수 추가 (cropImage)
                  - 크롭 자체가 scale과 비슷한 작동을 하므로 스케일은 삭제하였습니다.
                  - 회전은 연구 중입니다. 매트릭스까지 직접 컨트롤 할 필요는 없습니다.
                  
*수정 결과: 크롭 기능 (회전은 안 됨)

*수정 파일: 
1) ios/anilog/RNCCameraRollManager.m
                  - line 866 function requestImageData (추가됨)
                  - line 682 saveImage 함수 내, 상기 추가한 requestImageData 함수와 동일한 작업을 하던 부분이 함수로 대체됨

2) ios/anilog/RNCCameraRollManager.m
                  - line 714 function cropImage (추가됨)

3)  module/CameraRoll.d.ts
                  - line 185 type CropParams (추가됨)
                  - line 214 function cropImage (네이티브 함수 부르는 부분. 추가됨)

4) IosModuleTest_App.js
                  - 테스트용 Line 131 function cropImage (추가됨)


