### PR TITLE
[하늘] 스마트앨범 언어 지원 추가(한/영) *PR 대상 브랜치 수정

### DIFF
--- a/ios/anilog.xcodeproj/project.pbxproj
+++ b/ios/anilog.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		A72774053C0A480B90682CC4 /* Roboto-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9C12F8D39E3F46AA9ADA1233 /* Roboto-LightItalic.ttf */; };
 		B3C88654360E43C29548F8C8 /* Roboto-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F3F8D1B05DA044339A2953BF /* Roboto-Regular.ttf */; };
 		BA0CE0382852094F00E45F0D /* smartAlbums.strings in Resources */ = {isa = PBXBuildFile; fileRef = BA0CE0362852094F00E45F0D /* smartAlbums.strings */; };
+		BA0CE03E2852210100E45F0D /* smartAlbums.strings in Resources */ = {isa = PBXBuildFile; fileRef = BA0CE0402852210100E45F0D /* smartAlbums.strings */; };
 		BA879FE528141CB00052E1E1 /* RNCPermissionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = BA879FDF28141CB00052E1E1 /* RNCPermissionHandler.m */; };
 		BA879FE628141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = BA879FE328141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.m */; };
 		BA879FE728141CB00052E1E1 /* RNCCameraRollManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BA879FE428141CB00052E1E1 /* RNCCameraRollManager.m */; };
@@ -69,6 +70,7 @@
 		B079AF24774A2B10B60DFF49 /* libPods-anilog.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-anilog.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B7CC3F2370A94A2B8E77E173 /* Roboto-MediumItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Roboto-MediumItalic.ttf"; path = "../asset/fonts/Roboto-MediumItalic.ttf"; sourceTree = "<group>"; };
 		BA0CE0372852094F00E45F0D /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = smartAlbums.strings; sourceTree = "<group>"; };
+		BA0CE03F2852210100E45F0D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/smartAlbums.strings; sourceTree = "<group>"; };
 		BA879FDF28141CB00052E1E1 /* RNCPermissionHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RNCPermissionHandler.m; path = anilog/RNCPermissionHandler.m; sourceTree = "<group>"; };
 		BA879FE028141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNCAssetsLibraryRequestHandler.h; path = anilog/RNCAssetsLibraryRequestHandler.h; sourceTree = "<group>"; };
 		BA879FE128141CB00052E1E1 /* RNCPermissionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNCPermissionHandler.h; path = anilog/RNCPermissionHandler.h; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 		13B07FAE1A68108700A75B9A /* anilog */ = {
 			isa = PBXGroup;
 			children = (
+				BA0CE03B2852200D00E45F0D /* en.lproj */,
 				BA0CE0352852091A00E45F0D /* ko.lproj */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
@@ -201,6 +204,14 @@
 				BA0CE0362852094F00E45F0D /* smartAlbums.strings */,
 			);
 			path = ko.lproj;
+			sourceTree = "<group>";
+		};
+		BA0CE03B2852200D00E45F0D /* en.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				BA0CE0402852210100E45F0D /* smartAlbums.strings */,
+			);
+			name = en.lproj;
 			sourceTree = "<group>";
 		};
 		F162AB91FBE442F3891D9F68 /* Resources */ = {
@@ -333,6 +344,7 @@
 				BA0CE0382852094F00E45F0D /* smartAlbums.strings in Resources */,
 				61382C99BF2A4E959B782CC5 /* Roboto-Medium.ttf in Resources */,
 				39266251E14A4E1C9F361D92 /* Roboto-MediumItalic.ttf in Resources */,
+				BA0CE03E2852210100E45F0D /* smartAlbums.strings in Resources */,
 				B3C88654360E43C29548F8C8 /* Roboto-Regular.ttf in Resources */,
 				E6C58BF1C3784743B899A910 /* Roboto-Thin.ttf in Resources */,
 				5A12A690994F4E089B3007C2 /* Roboto-ThinItalic.ttf in Resources */,
@@ -354,7 +366,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nexport NODE_BINARY=/opt/homebrew/bin/node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
+			shellScript = "set -e\n\nexport NODE_BINARY=/Users/mabel/.nvm/versions/node/v16.13.2/bin/node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 		1363ED4656547214606772C7 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -525,6 +537,14 @@
 			isa = PBXVariantGroup;
 			children = (
 				BA0CE0372852094F00E45F0D /* ko */,
+			);
+			name = smartAlbums.strings;
+			sourceTree = "<group>";
+		};
+		BA0CE0402852210100E45F0D /* smartAlbums.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				BA0CE03F2852210100E45F0D /* en */,
 			);
 			name = smartAlbums.strings;
 			sourceTree = "<group>";

--- a/ios/anilog.xcodeproj/project.pbxproj
+++ b/ios/anilog.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		A6656D5242D64B84A760D9E9 /* Roboto-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 76509BC8278D4CF685E56AD9 /* Roboto-BoldItalic.ttf */; };
 		A72774053C0A480B90682CC4 /* Roboto-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9C12F8D39E3F46AA9ADA1233 /* Roboto-LightItalic.ttf */; };
 		B3C88654360E43C29548F8C8 /* Roboto-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F3F8D1B05DA044339A2953BF /* Roboto-Regular.ttf */; };
+		BA0CE0382852094F00E45F0D /* smartAlbums.strings in Resources */ = {isa = PBXBuildFile; fileRef = BA0CE0362852094F00E45F0D /* smartAlbums.strings */; };
 		BA879FE528141CB00052E1E1 /* RNCPermissionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = BA879FDF28141CB00052E1E1 /* RNCPermissionHandler.m */; };
 		BA879FE628141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = BA879FE328141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.m */; };
 		BA879FE728141CB00052E1E1 /* RNCCameraRollManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BA879FE428141CB00052E1E1 /* RNCCameraRollManager.m */; };
@@ -67,6 +68,7 @@
 		AAC775FFF43F4592ABC47E11 /* Roboto-Light.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Roboto-Light.ttf"; path = "../asset/fonts/Roboto-Light.ttf"; sourceTree = "<group>"; };
 		B079AF24774A2B10B60DFF49 /* libPods-anilog.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-anilog.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B7CC3F2370A94A2B8E77E173 /* Roboto-MediumItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Roboto-MediumItalic.ttf"; path = "../asset/fonts/Roboto-MediumItalic.ttf"; sourceTree = "<group>"; };
+		BA0CE0372852094F00E45F0D /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = smartAlbums.strings; sourceTree = "<group>"; };
 		BA879FDF28141CB00052E1E1 /* RNCPermissionHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RNCPermissionHandler.m; path = anilog/RNCPermissionHandler.m; sourceTree = "<group>"; };
 		BA879FE028141CB00052E1E1 /* RNCAssetsLibraryRequestHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNCAssetsLibraryRequestHandler.h; path = anilog/RNCAssetsLibraryRequestHandler.h; sourceTree = "<group>"; };
 		BA879FE128141CB00052E1E1 /* RNCPermissionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNCPermissionHandler.h; path = anilog/RNCPermissionHandler.h; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 		13B07FAE1A68108700A75B9A /* anilog */ = {
 			isa = PBXGroup;
 			children = (
+				BA0CE0352852091A00E45F0D /* ko.lproj */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
@@ -190,6 +193,14 @@
 				00E356EE1AD99517003FC87E /* anilogTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		BA0CE0352852091A00E45F0D /* ko.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				BA0CE0362852094F00E45F0D /* smartAlbums.strings */,
+			);
+			path = ko.lproj;
 			sourceTree = "<group>";
 		};
 		F162AB91FBE442F3891D9F68 /* Resources */ = {
@@ -283,6 +294,7 @@
 			knownRegions = (
 				en,
 				Base,
+				ko,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
@@ -318,6 +330,7 @@
 				38C809C2E250425DBE6E3698 /* Roboto-Italic.ttf in Resources */,
 				7E1C798840BD4BBB9496F685 /* Roboto-Light.ttf in Resources */,
 				A72774053C0A480B90682CC4 /* Roboto-LightItalic.ttf in Resources */,
+				BA0CE0382852094F00E45F0D /* smartAlbums.strings in Resources */,
 				61382C99BF2A4E959B782CC5 /* Roboto-Medium.ttf in Resources */,
 				39266251E14A4E1C9F361D92 /* Roboto-MediumItalic.ttf in Resources */,
 				B3C88654360E43C29548F8C8 /* Roboto-Regular.ttf in Resources */,
@@ -506,6 +519,17 @@
 			targetProxy = 00E356F41AD99517003FC87E /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		BA0CE0362852094F00E45F0D /* smartAlbums.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				BA0CE0372852094F00E45F0D /* ko */,
+			);
+			name = smartAlbums.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {

--- a/ios/anilog/RNCCameraRollManager.m
+++ b/ios/anilog/RNCCameraRollManager.m
@@ -213,13 +213,6 @@ RCT_EXPORT_METHOD(getAlbums:(NSDictionary *)params
   NSMutableArray * result = [NSMutableArray new];
   NSString *__block fetchedAlbumType = nil;
   
-  //콜백함수 선언
-  //반환형 (^블록명)(파라미터 타입); void (^blockName)(double, double);
-  //- (void)exampleMethodName:(블록 선언이 들어갈 자리인데 생략가능)블록 이름;
-  //- (void)exampleMethodName:(void (^blockName)(void))methodBlockName;
-  //- (void)exampleMethodName:(void (^)(void))methodBlockName;
-  //methodBlockName은 exampleMethodName 함수 안에서 쓸 블록 이름입니다.
-  //exampleMethodName 안에서 methodBlockName()으로 호출도 가능합니다.
   void (^convertAsset)(PHAssetCollection * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) =
   ^(PHAssetCollection * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
     PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType fromTime:0 toTime:0];
@@ -230,7 +223,7 @@ RCT_EXPORT_METHOD(getAlbums:(NSDictionary *)params
     //리턴형태
     if (assetsFetchResult.count > 0) {
       [result addObject:@{
-        @"title": [obj localizedTitle],
+        @"title": ([obj assetCollectionType] != PHAssetCollectionTypeSmartAlbum) ? [obj localizedTitle] : NSLocalizedStringFromTable([obj localizedTitle], @"smartAlbums", nil),
         @"count": @(assetsFetchResult.count),
         @"type": fetchedAlbumType,
         @"subType": @(obj.assetCollectionSubtype)
@@ -440,7 +433,8 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         assetCollectionFetchResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:subType options:nil];
         [assetCollectionFetchResult enumerateObjectsUsingBlock:^(PHAssetCollection * _Nonnull assetCollection, NSUInteger collectionIdx, BOOL * _Nonnull stopCollections) {
           PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:assetCollection options:assetFetchOptions];
-          currentCollectionName = [assetCollection localizedTitle];
+//          currentCollectionName = [assetCollection localizedTitle];
+          currentCollectionName = NSLocalizedStringFromTable([assetCollection localizedTitle], @"smartAlbums", nil);
           [assetsFetchResult enumerateObjectsUsingBlock:collectAsset];
           
           *stopCollections = stopCollections_;

--- a/ios/en.lproj/smartAlbums.strings
+++ b/ios/en.lproj/smartAlbums.strings
@@ -1,0 +1,21 @@
+"Recents" = "Recents";
+"Favorites" = "Favorites";
+"Panoramas" = "Panoramas";
+"Videos" = "Videos";
+"Time-lapse" = "Time-lapse";
+"Hidden" = "Hidden";
+"Recently Deleted" = "Recently Deleted";
+"Bursts" = "Bursts";
+"Slo-mo" = "Slo-mo";
+"Recently Added" = "Recently Added";
+"Selfies" = "Selfies";
+"Screenshots" = "Screenshots";
+"Portrait" = "Portrait";
+"Live Photoes" = "Live Photoes";
+"Animated" = "Animated";
+"Long Exposure" = "Long Exposure";
+"Unable to Upload" = "Unable to Upload";
+"RAW" = "RAW";
+
+
+

--- a/ios/ko.lproj/smartAlbums.strings
+++ b/ios/ko.lproj/smartAlbums.strings
@@ -1,0 +1,21 @@
+"Recents" = "최근 항목";
+"Favorites" = "즐겨찾기";
+"Panoramas" = "파노라마";
+"Videos" = "비디오";
+"Time-lapse" = "타임랩스";
+"Hidden" = "가려진 항목";
+"Recently Deleted" = "최근 삭제된 항목";
+"Bursts" = "버스트";
+"Slo-mo" = "슬로 모션";
+"Recently Added" = "최근 추가된 항목";
+"Selfies" = "셀카";
+"Screenshots" = "스크린샷";
+"Portrait" = "인물 사진";
+"Live Photoes" = "라이브 포토";
+"Animated" = "Animated";
+"Long Exposure" = "Long Exposure";
+"Unable to Upload" = "Unable to Upload";
+"RAW" = "RAW";
+
+
+


### PR DESCRIPTION
*수정 사항: iOS 스마트앨범 한국어 지원 추가
*수정 결과: 카메라롤 앨범명 결과값이 한국어/영어(미국)로 나옴
*수정 파일: 1) ios/anilog/RNCCameraRollManager.m line 226, 437
2) 스트링 대응 파일 추가: ios/ko.lproj/smartAlbums.strings (한국어 대응) 와 ios/en.lproj/smartAlbums.strings (영어 대응-기존-)
3) ios/anilog.xcodeproj/project.pbxproj (localization 설정 추가)