### PR TITLE
[상우] UI 4차 오류 수정 / 댓글 스크롤 및 댓글의 사진 추가 관련 오류 사항 수정

### DIFF
--- a/src/component/molecules/input/HashInput.js
+++ b/src/component/molecules/input/HashInput.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text, TouchableWithoutFeedback, Platform, StyleSheet, TextInput} from 'react-native';
+import {View, Text, TouchableWithoutFeedback, Platform, StyleSheet, TextInput, TouchableOpacity} from 'react-native';
 import AccountHashList from 'Organism/list/AccountHashList';
 import {APRI10, BLACK, GRAY10, GRAY20} from 'Root/config/color';
 import {findTagAt, isTag, getTagName, findStartIndexOfTag, findEndIndexOfTag} from 'Root/util/stringutil';
@@ -248,14 +248,18 @@ const HashInput = React.forwardRef((props, ref) => {
 		return result;
 	};
 
+	const giveFocus = () => {
+		inputRef.current.focus();
+	};
+
 	return (
 		<>
-			<View style={[props.containerStyle, {}]} ref={ref}>
-				<View>
+			<TouchableOpacity activeOpacity={1} onPress={giveFocus} style={[props.containerStyle, {}]} ref={ref}>
+				<View style={{}}>
 					{location == undefined ? (
 						false
 					) : (
-						<View style={{flexDirection: 'row', alignItems: 'center', height: 40 * DP, maxWidth: 550 * DP}}>
+						<View style={{flexDirection: 'row', alignItems: 'center', height: 40 * DP, width: '95%'}}>
 							<Location40Border />
 							<Text style={[txt.noto26, {color: BLACK, lineHeight: 30 * DP}]} numberOfLines={1}>
 								{getLocation()}
@@ -264,7 +268,14 @@ const HashInput = React.forwardRef((props, ref) => {
 					)}
 					<TextInput
 						{...props} //props override
-						style={[{marginBottom: props.selectedImg.length > 0 ? 10 * DP : 0}, txt.noto28]}
+						style={[
+							{marginBottom: props.selectedImg.length > 0 ? 10 * DP : 0},
+							txt.noto28,
+							{
+								// minHeight: props.showImages && props.selectedImg.length > 0 ? 170 * DP : props.containerStyle[0].minHeight - 48 * DP,
+								// backgroundColor: 'palegreen',
+							},
+						]}
 						textAlignVertical={'top'}
 						multiline={true}
 						value={value}
@@ -283,10 +294,10 @@ const HashInput = React.forwardRef((props, ref) => {
 						<SelectedMediaList items={props.selectedImg} onDelete={deletePhoto} />
 					</View>
 				)}
-			</View>
+			</TouchableOpacity>
 
 			{find && (
-				<View style={{width: '100%', flex: 1, padding: 15 * DP}}>
+				<View style={{width: 694 * DP, flex: 1, padding: 15 * DP}}>
 					{/* <AccountList items={findList} onSelect={userSelect} makeBorderMode={false} showCrossMark={false} /> */}
 					<AccountHashList data={findList} showFollowBtn={false} onClickLabel={userSelect} onClickHash={hashSelect} />
 				</View>

--- a/src/component/molecules/media/FeedMedia.js
+++ b/src/component/molecules/media/FeedMedia.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Text, View, Image, TouchableOpacity, StyleSheet, ScrollView, BackHandler} from 'react-native';
+import {Text, View, Image, TouchableOpacity, StyleSheet} from 'react-native';
 import {txt} from 'Root/config/textstyle';
 import DP from 'Root/config/dp';
 import {ImageList48, VideoPlay48, VideoPlay_Feed, Tag70, Blur694} from 'Atom/icon';
@@ -103,25 +103,7 @@ export default FeedMedia = props => {
 		} else return false;
 	};
 
-	const [showImgMode, setShowImgMode] = React.useState(false);
-	const backAction = () => {
-		console.log('back', showImgMode);
-		if (showImgMode) {
-			Modal.close();
-			setShowImgMode(false);
-			return true;
-		} else {
-			return false;
-		}
-	};
-
-	React.useEffect(() => {
-		BackHandler.addEventListener('hardwareBackPress', backAction);
-		return () => BackHandler.removeEventListener('hardwareBackPress', backAction);
-	}, [showImgMode]);
-
 	const onPressPhoto = () => {
-		setShowImgMode(true);
 		Modal.popPhotoListViewModal(
 			feed_medias.map(v => v.media_uri),
 			() => Modal.close(),

--- a/src/component/molecules/modal/PhotoListViewModal.js
+++ b/src/component/molecules/modal/PhotoListViewModal.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, Text, StyleSheet, Platform, Dimensions, Image, TouchableOpacity} from 'react-native';
+import {View, Text, StyleSheet, Platform, Dimensions, Image, TouchableOpacity, BackHandler} from 'react-native';
 import {WHITE, GRAY10, APRI10} from 'Root/config/color';
 import {txt} from 'Root/config/textstyle';
 import DP from 'Root/config/dp';
@@ -20,6 +20,23 @@ import Crop from 'Molecules/media/Crop';
  */
 const PhotoListViewModal = props => {
 	const swiperRef = React.useRef();
+
+	const [showImgMode, setShowImgMode] = React.useState(true);
+	const backAction = () => {
+		console.log('backAction', showImgMode);
+		if (showImgMode) {
+			Modal.close();
+			setShowImgMode(false);
+			return true;
+		} else {
+			return false;
+		}
+	};
+
+	React.useEffect(() => {
+		BackHandler.addEventListener('hardwareBackPress', backAction);
+		return () => BackHandler.removeEventListener('hardwareBackPress', backAction);
+	}, [showImgMode]);
 
 	return (
 		<View style={style.background}>

--- a/src/component/molecules/modal/ReviewFilterModal.js
+++ b/src/component/molecules/modal/ReviewFilterModal.js
@@ -293,9 +293,10 @@ const ReviewFilterModal = props => {
 				let districts = arr.concat(result.msg);
 				districts.push(padding);
 				districts.push(padding);
-				setDistrict(districts);
-				setSelectedDistrict(result.msg[0]);
-				setSelectedItem_dis(2);
+				//시,군,구가 자동으로 바뀌지 않도록 주석처리
+				// setDistrict(districts);
+				// setSelectedDistrict(result.msg[0]);
+				// setSelectedItem_dis(2);
 			},
 			err => {
 				console.log('err', err);

--- a/src/component/organism/article/ArticleContent.js
+++ b/src/component/organism/article/ArticleContent.js
@@ -1,17 +1,13 @@
 import React from 'react';
 import {txt} from 'Root/config/textstyle';
-import {BackHandler, Dimensions, Image, LogBox, Platform, StyleSheet, Text, TouchableOpacity, View} from 'react-native';
+import {LogBox, Platform, StyleSheet, Text, View} from 'react-native';
 import DP from 'Root/config/dp';
-import {APRI10, BLACK, GRAY40} from 'Root/config/color';
-import {FavoriteTag46_Filled, FavoriteTag48_Border, Meatball50_GRAY20_Horizontal} from 'Root/component/atom/icon';
+import {GRAY40} from 'Root/config/color';
 import UserLocationTimeLabel from 'Root/component/molecules/label/UserLocationTimeLabel';
-import {styles} from 'Root/component/atom/image/imageStyle';
 import WebView from 'react-native-webview';
-import userGlobalObject from 'Root/config/userGlobalObject';
 import Modal from 'Root/component/modal/Modal';
 import {useNavigation} from '@react-navigation/core';
 import AutoHeightWebView from 'Root/module/AutoHeightWebview';
-import FastImage from 'react-native-fast-image';
 /**
  * 게시글 컨텐츠
  * @param {object} props - Props Object
@@ -32,53 +28,8 @@ const ArticleContent = props => {
 		setData(props.data);
 	}, [props.data]);
 
-	const onPressMeatball = () => {
-		props.onPressMeatball();
-	};
-
-	const onPressFavorite = bool => {
-		if (userGlobalObject.userInfo.isPreviewMode) {
-			Modal.popLoginRequestModal(() => {
-				navigation.navigate('LoginRequired');
-			});
-		} else {
-			setData({...data, community_is_favorite: bool});
-			props.onPressFavorite(bool);
-		}
-	};
-	const [showImgMode, setShowImgMode] = React.useState(false);
-	const backAction = () => {
-		console.log('back', showImgMode);
-		if (showImgMode) {
-			Modal.close();
-			setShowImgMode(false);
-			return true;
-		} else {
-			return false;
-		}
-	};
-
-	React.useEffect(() => {
-		BackHandler.addEventListener('hardwareBackPress', backAction);
-		return () => BackHandler.removeEventListener('hardwareBackPress', backAction);
-	}, [showImgMode]);
-
 	const showImg = src => {
-		setShowImgMode(true);
 		Modal.popPhotoListViewModal([src], () => Modal.close());
-	};
-
-	const getArticleType = () => {
-		switch (data.community_free_type) {
-			case 'talk':
-				return '잡담';
-			case 'question':
-				return '질문';
-			case 'meeting':
-				return '모임';
-			default:
-				break;
-		}
 	};
 
 	const onWebViewMessage = async event => {

--- a/src/component/organism/article/ArticleContent.js
+++ b/src/component/organism/article/ArticleContent.js
@@ -126,7 +126,7 @@ const ArticleContent = props => {
 			};  border-radius:15px; object-fit:contain; margin:5px 0px 0px 0px; " `,
 		);
 		// console.log('data Content', data.community_content);
-		console.log('result', result);
+		// console.log('result', result);
 		return `
 		<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0">
         <script>

--- a/src/component/organism/comment/ChildComment.js
+++ b/src/component/organism/comment/ChildComment.js
@@ -3,7 +3,7 @@ import {Image, Text, View, StyleSheet, TouchableOpacity} from 'react-native';
 import {GRAY10, GRAY20} from 'Root/config/color';
 import {txt} from 'Root/config/textstyle';
 import {Heart30_Border, Heart30_Filled, Meatball50_GRAY20_Vertical, Report30, SecureIcon40} from 'Atom/icon';
-import {DEFAULT_PROFILE, REPLY_MEATBALL_MENU, REPLY_MEATBALL_MENU_MY_REPLY} from 'Root/i18n/msg';
+import {REPLY_MEATBALL_MENU_MY_REPLY} from 'Root/i18n/msg';
 import {styles} from 'Atom/image/imageStyle';
 import UserTimeLabel from 'Molecules/label/UserTimeLabel';
 import {useNavigation} from '@react-navigation/native';
@@ -92,6 +92,10 @@ const ChildComment = props => {
 				);
 			}
 		}
+	};
+
+	const onPressReplyPhoto = src => {
+		Modal.popPhotoListViewModal([src], Modal.close);
 	};
 
 	const reportComment = () => {
@@ -183,13 +187,13 @@ const ChildComment = props => {
 			</View>
 			{/* 해당 대댓글이 photo_uri를 가지고 있는 경우만 IMage 출력 */}
 			{data.comment_photo_uri != null && !isNotAuthorized() ? (
-				<View style={[childComment.img_square_round_484]}>
+				<TouchableOpacity onPress={() => onPressReplyPhoto(data.comment_photo_uri)} activeOpacity={0.8} style={[childComment.img_square_round_484]}>
 					{data.comment_photo_uri.includes('http') ? (
 						<FastImage style={[styles.img_square_round_544]} source={{uri: data.comment_photo_uri}} />
 					) : (
 						<Image style={[styles.img_square_round_544]} source={{uri: data.comment_photo_uri}} />
 					)}
-				</View>
+				</TouchableOpacity>
 			) : (
 				<></>
 			)}

--- a/src/component/organism/comment/ChildCommentList.js
+++ b/src/component/organism/comment/ChildCommentList.js
@@ -22,7 +22,7 @@ const ChildCommentList = props => {
 
 	const renderItem = ({item, index}) => {
 		return (
-			<View style={[style.childCommentList, {backgroundColor: props.editData && props.editData._id == item._id ? GRAY40 : null}]}>
+			<View style={[style.childCommentList, {backgroundColor: props.editData && props.editData._id == item._id ? GRAY40 : 'white'}]}>
 				<ChildCommentLinker />
 				<ChildComment data={item} onEdit={onEdit} like={like} onPressDeleteChild={props.onPressDeleteChild} />
 			</View>
@@ -41,7 +41,10 @@ export default ChildCommentList;
 
 const style = StyleSheet.create({
 	childCommentList: {
-		// width: 750 * DP,
+		width: 750 * DP,
+		marginRight: -28 * DP,
+		paddingRight: 28 * DP,
+		justifyContent: 'flex-end',
 		paddingVertical: 20 * DP,
 		flexDirection: 'row',
 	},

--- a/src/component/organism/comment/ParentComment.js
+++ b/src/component/organism/comment/ParentComment.js
@@ -154,7 +154,7 @@ export default ParentComment = React.memo((props, ref) => {
 				}
 			}
 		}
-		props.onEdit && props.onEdit(data, parent._id, {findIndex: findIndex, hasPhoto: hasPhoto.length});
+		props.onEdit && props.onEdit(data, parent, {findIndex: findIndex, hasPhoto: hasPhoto.length});
 	};
 
 	const onDelete = () => {
@@ -169,6 +169,10 @@ export default ParentComment = React.memo((props, ref) => {
 		setTimeout(() => {
 			showChildComment();
 		}, 200);
+	};
+
+	const onPressReplyPhoto = src => {
+		Modal.popPhotoListViewModal([src], Modal.close);
 	};
 
 	//좋아요 클릭
@@ -257,13 +261,13 @@ export default ParentComment = React.memo((props, ref) => {
 			{data.comment_photo_uri == undefined || isNotAuthorized() ? (
 				<></>
 			) : (
-				<View style={[style.img_square_round]}>
+				<TouchableOpacity onPress={() => onPressReplyPhoto(data.comment_photo_uri)} activeOpacity={0.8} style={[style.img_square_round]}>
 					{data.comment_photo_uri.includes('http') ? (
 						<FastImage style={[styles.img_square_round_614]} source={{uri: data.comment_photo_uri}} />
 					) : (
 						<Image style={[styles.img_square_round_614]} source={{uri: data.comment_photo_uri}} />
 					)}
-				</View>
+				</TouchableOpacity>
 			)}
 			{/* 댓글 내용 */}
 			{data.comment_is_delete ? (
@@ -321,7 +325,7 @@ export default ParentComment = React.memo((props, ref) => {
 			)}
 			{/* Data - 대댓글List */}
 			{showChild ? (
-				<View style={[style.childCommentList]}>
+				<View style={[style.childCommentList, {}]}>
 					<ChildCommentList
 						items={child}
 						showChildComment={showChildComment}
@@ -351,7 +355,7 @@ const style = StyleSheet.create({
 	parentComment: {
 		flexDirection: 'column',
 		width: 694 * DP,
-		marginBottom: 20 * DP,
+		// marginBottom: 20 * DP,
 		alignItems: 'flex-end',
 		// backgroundColor: 'yellow',
 	},
@@ -427,5 +431,9 @@ const style = StyleSheet.create({
 		// width: 614 * DP,
 		// marginTop: 20 * DP,
 		flexDirection: 'row',
+		width: 750 * DP,
+		justifyContent: 'flex-end',
+		backgroundColor: 'white',
+		alignItems: 'flex-end',
 	},
 });

--- a/src/component/organism/comment/ParentComment.js
+++ b/src/component/organism/comment/ParentComment.js
@@ -33,27 +33,34 @@ export default ParentComment = React.memo((props, ref) => {
 	// console.log('ParentComment : ', props.parentComment.comment_writer_id.user_nickname, props.parentComment.comment_is_secure);
 	// console.log('parentComment props', props.parentComment.comment_contents, props.parentComment.children_count);
 	const navigation = useNavigation();
-	const [data, setData] = React.useState(props.parentComment);
+	const parent = props.parentComment;
+	const [data, setData] = React.useState(parent);
 	const [child, setChild] = React.useState([]);
 	const [likeCount, setLikeCount] = React.useState(0);
 	const [likeState, setLikeState] = React.useState(false); //해당 댓글의 좋아요 상태 - 로그인 유저가 좋아요를 누른 기록이 있다면 filled , or border
 	const [showChild, setShowChild] = React.useState(false); //해당 댓글의 답글들 출력 여부 Boolean
-	const [meatball, setMeatball] = React.useState(false); // 해당 댓글의 미트볼 헤더 클릭 여부
+
 	React.useEffect(() => {
-		setData(props.parentComment);
-		setLikeState(props.parentComment.comment_is_like);
-		setLikeCount(props.parentComment.comment_like_count);
-		if (props.parentComment.showChild) {
-			// console.log('props.parentComment.showChild', props.parentComment.showChild);
+		setData(parent);
+		setLikeState(parent.comment_is_like);
+		setLikeCount(parent.comment_like_count);
+		//
+		if (parent && parent.isDeleted && parent.children_count > 0) {
+			console.log('parent.showChild', parent.isDeleted, parent.comment_contents);
 			setTimeout(() => {
-				// showChildComment();
 				setShowChild(true);
+			}, 300);
+		}
+		if (parent && parent.isEdited && parent.children_count > 0) {
+			console.log('parent.isEdited', parent.isEdited, parent.comment_contents);
+			setTimeout(() => {
+				addChildComment();
 			}, 300);
 		}
 	}, [props.parentComment]);
 
 	React.useEffect(() => {
-		if (props.parentComment._id == props.parent) {
+		if (parent._id == props.parent) {
 			showChildComment();
 		}
 		if (props.openChild) {
@@ -66,7 +73,7 @@ export default ParentComment = React.memo((props, ref) => {
 	const addChildComment = newChildComment => {
 		getChildCommentList(
 			{
-				commentobject_id: props.parentComment._id,
+				commentobject_id: parent._id,
 				login_userobject_id: userGlobalObject.userInfo._id,
 			},
 			result => {
@@ -82,9 +89,9 @@ export default ParentComment = React.memo((props, ref) => {
 
 	//답글쓰기 클릭
 	const onPressReplyBtn = () => {
-		// console.log('대댓글 추가 부모댓글 닉네임 : ', props.parentComment.comment_writer_id.user_nickname);
-		if (props.parentComment.comment_writer_id) {
-			props.onPressReplyBtn(props.parentComment, addChildComment);
+		// console.log('대댓글 추가 부모댓글 닉네임 : ', parent.comment_writer_id.user_nickname);
+		if (parent.comment_writer_id) {
+			props.onPressReplyBtn(parent, addChildComment);
 		} else {
 			Modal.popNetworkErrorModal('이미 탈퇴한 계정의 댓글입니다.');
 		}
@@ -99,7 +106,7 @@ export default ParentComment = React.memo((props, ref) => {
 			setLikeState(!likeState);
 			likeComment(
 				{
-					commentobject_id: props.parentComment._id,
+					commentobject_id: parent._id,
 					userobject_id: userGlobalObject.userInfo._id,
 					is_like: !likeState,
 				},
@@ -110,7 +117,7 @@ export default ParentComment = React.memo((props, ref) => {
 					console.log(error);
 				},
 			);
-			props.like && props.like(props.parentComment);
+			props.like && props.like(parent);
 		}
 	};
 
@@ -118,7 +125,7 @@ export default ParentComment = React.memo((props, ref) => {
 	const showChildComment = () => {
 		getChildCommentList(
 			{
-				commentobject_id: props.parentComment._id,
+				commentobject_id: parent._id,
 				login_userobject_id: userGlobalObject.userInfo._id,
 			},
 			result => {
@@ -135,8 +142,19 @@ export default ParentComment = React.memo((props, ref) => {
 
 	//미트볼 -> 수정 클릭
 	const onEdit = data => {
-		// console.log('props.parentComment', props.parentComment);
-		props.onEdit && props.onEdit(data, props.parentComment._id);
+		// console.log('parent', parent);
+		// console.log('data', data);
+		const findIndex = child.findIndex(e => e._id == data._id);
+		let hasPhoto = [];
+		if (findIndex != -1) {
+			for (let i = 0; i < findIndex; i++) {
+				console.log('i', i, child[i].comment_photo_uri);
+				if (child[i].comment_photo_uri) {
+					hasPhoto.push(true);
+				}
+			}
+		}
+		props.onEdit && props.onEdit(data, parent._id, {findIndex: findIndex, hasPhoto: hasPhoto.length});
 	};
 
 	const onDelete = () => {
@@ -147,7 +165,7 @@ export default ParentComment = React.memo((props, ref) => {
 	};
 
 	const onPressDeleteChild = id => {
-		props.onPressDeleteChild(id, props.parentComment);
+		props.onPressDeleteChild(id, parent);
 		setTimeout(() => {
 			showChildComment();
 		}, 200);
@@ -156,41 +174,6 @@ export default ParentComment = React.memo((props, ref) => {
 	//좋아요 클릭
 	const like = data => {
 		props.like && props.like(data);
-	};
-
-	//미트볼 클릭
-	const onPressMeatball = () => {
-		// console.log('data', data.comment_writer_id);
-		if (data.comment_writer_id) {
-			const isWriter = userGlobalObject.userInfo._id == data.comment_writer_id._id;
-			if (isWriter) {
-				Modal.popSelectBoxModal(
-					REPLY_MEATBALL_MENU_MY_REPLY,
-					selectedItem => {
-						switch (selectedItem) {
-							case '수정':
-								onEdit(props.parentComment);
-								break;
-							case '삭제':
-								onDelete();
-								break;
-							case '상태 변경':
-								alert('상태 변경!');
-								break;
-							case '공유하기':
-								alert('공유하기!');
-								break;
-							default:
-								break;
-						}
-						Modal.close();
-					},
-					() => Modal.close(),
-					false,
-					'',
-				);
-			}
-		}
 	};
 
 	const reportComment = () => {
@@ -249,7 +232,7 @@ export default ParentComment = React.memo((props, ref) => {
 		return result;
 	};
 
-	const childrenCount = child.length > 0 ? child.length : props.parentComment.children_count;
+	const childrenCount = child.length > 0 ? child.length : parent.children_count;
 
 	return (
 		<View style={[style.parentComment]}>
@@ -269,16 +252,9 @@ export default ParentComment = React.memo((props, ref) => {
 						<></>
 					)}
 				</View>
-				{/* {data.comment_is_delete || !data.comment_writer_id || userGlobalObject.userInfo._id != data.comment_writer_id._id ? (
-					<></>
-				) : (
-					<View style={[]}>
-						<Meatball50_GRAY20_Vertical onPress={onPressMeatball} />
-					</View>
-				)} */}
 			</View>
 			{/* 댓글 Dummy 이미지 및 대댓글 목록 */}
-			{data.comment_photo_uri == undefined || isNotAuthorized() ? ( //img_square_round_574
+			{data.comment_photo_uri == undefined || isNotAuthorized() ? (
 				<></>
 			) : (
 				<View style={[style.img_square_round]}>
@@ -313,7 +289,7 @@ export default ParentComment = React.memo((props, ref) => {
 							<TouchableOpacity onPress={onDelete} style={[{}]}>
 								<Text style={[txt.noto24, {color: GRAY10}]}> 삭제 · </Text>
 							</TouchableOpacity>
-							<TouchableOpacity onPress={() => onEdit(props.parentComment)} style={[{}]}>
+							<TouchableOpacity onPress={() => onEdit(parent)} style={[{}]}>
 								<Text style={[txt.noto24, {color: GRAY10}]}> 수정 · </Text>
 							</TouchableOpacity>
 						</View>

--- a/src/component/organism/feed/FeedContent.js
+++ b/src/component/organism/feed/FeedContent.js
@@ -206,25 +206,32 @@ export default FeedContent = props => {
 	//피드 미트볼 메뉴 - 쪽지 보내기
 	const onPressSendMsg = _id => {
 		Modal.close();
+
 		setTimeout(() => {
-			Modal.popMessageModal(
-				_id.user_nickname,
-				msg => {
-					createMemoBox(
-						{memobox_receive_id: _id._id, memobox_contents: msg},
-						result => {
-							console.log('message sent success', result);
-							Modal.popOneBtn('쪽지 전송하였습니다.', '확인', () => Modal.close());
-						},
-						err => {
-							console.log('message sent err', err);
-						},
-					);
-					console.log('msg', msg);
-					Modal.close();
-				},
-				() => alert('나가기'),
-			);
+			if (userGlobalObject.userInfo.isPreviewMode) {
+				Modal.popLoginRequestModal(() => {
+					navigation.navigate('LoginRequired');
+				});
+			} else {
+				Modal.popMessageModal(
+					_id.user_nickname,
+					msg => {
+						createMemoBox(
+							{memobox_receive_id: _id._id, memobox_contents: msg},
+							result => {
+								console.log('message sent success', result);
+								Modal.popOneBtn('쪽지 전송하였습니다.', '확인', () => Modal.close());
+							},
+							err => {
+								console.log('message sent err', err);
+							},
+						);
+						console.log('msg', msg);
+						Modal.close();
+					},
+					() => alert('나가기'),
+				);
+			}
 		}, 100);
 	};
 

--- a/src/component/organism/input/ReplyWriteBox.js
+++ b/src/component/organism/input/ReplyWriteBox.js
@@ -90,7 +90,7 @@ const ReplyWriteBox = React.forwardRef((props, ref) => {
 				</View>
 			);
 		} else {
-			return <></>;
+			return <View style={{height: 20 * DP}}></View>;
 		}
 	};
 
@@ -326,7 +326,8 @@ const style = StyleSheet.create({
 	},
 	commentBox: {
 		width: 750 * DP,
-		paddingVertical: 28 * DP,
+		// paddingVertical: 28 * DP,
+		paddingBottom: 10 * DP,
 		paddingHorizontal: 20 * DP,
 		alignItems: 'center',
 		// backgroundColor: 'yellow',

--- a/src/component/organism/list/NoteList.js
+++ b/src/component/organism/list/NoteList.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {FlatList, ScrollView, Text, View, StyleSheet, SafeAreaView} from 'react-native';
-import UserAccount from 'Organism/listitem/UserAccount';
 import {accountHashList} from 'Organism/style_organism copy';
 import UserNote from '../listitem/UserNote';
 

--- a/src/component/organism/list/NoteMessageList.js
+++ b/src/component/organism/list/NoteMessageList.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {FlatList, ScrollView, Text, View, StyleSheet} from 'react-native';
-import UserAccount from 'Organism/listitem/UserAccount';
 import {accountHashList} from 'Organism/style_organism copy';
 import OneMessage from 'Organism/listitem/OneMessage';
 

--- a/src/component/organism/listitem/OneAlarm.js
+++ b/src/component/organism/listitem/OneAlarm.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {View, TouchableOpacity, Text, StyleSheet, Image} from 'react-native';
 import AniButton from 'Molecules/button/AniButton';
 import CheckBox from 'Molecules/select/CheckBox';
-import {userAccount} from 'Organism/style_organism copy';
 import {txt} from 'Root/config/textstyle';
 import DP from 'Root/config/dp';
 import {GRAY10, APRI10, BLACK, APRI20, WHITE, MAINBLACK} from 'Root/config/color';
@@ -128,7 +127,7 @@ const styles = StyleSheet.create({
 	},
 });
 
-UserAccount.defaultProps = {
+OneAlarm.defaultProps = {
 	// onLabelClick: e => console.log(e),
 	onClickFollow: e => console.log(e),
 	onCheckBox: e => console.log(e),

--- a/src/component/organism/listitem/OneMessage.js
+++ b/src/component/organism/listitem/OneMessage.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {FlatList, ScrollView, Text, View, StyleSheet, Image, TouchableOpacity} from 'react-native';
-import UserAccount from 'Organism/listitem/UserAccount';
 import {accountHashList} from 'Organism/style_organism copy';
 import UserNote from './UserNote';
 import DP from 'Root/config/dp';

--- a/src/component/organism/listitem/UserAccount.js
+++ b/src/component/organism/listitem/UserAccount.js
@@ -22,7 +22,7 @@ export default UserAccount = props => {
 
 	const getLabel = () => {
 		if (props.data.type === 'UserObject') {
-			return <UserDescriptionLabel data={props.data} onClickLabel={e => props.onLabelClick(e)} width={500} />;
+			return <UserDescriptionLabel data={props.data} showFollowStatusText={true} onClickLabel={e => props.onLabelClick(e)} width={500} />;
 		} else if (props.data.type === 'HashTagObject') {
 			return (
 				<TouchableOpacity onPress={() => props.onHashClick()}>

--- a/src/component/organism/listitem/UserNote.js
+++ b/src/component/organism/listitem/UserNote.js
@@ -118,7 +118,7 @@ const styles = StyleSheet.create({
 	},
 });
 
-UserAccount.defaultProps = {
+UserNote.defaultProps = {
 	onLabelClick: e => console.log(e),
 	onClickFollow: e => console.log(e),
 	onCheckBox: e => console.log(e),

--- a/src/component/organism/style_organism copy.js
+++ b/src/component/organism/style_organism copy.js
@@ -957,7 +957,7 @@ export const selectedMediaList = StyleSheet.create({
 		// width: 190 * DP,
 		// height: 190 * DP,
 		// marginRight: 30 * DP,
-		marginLeft: 22 * DP,
+		marginLeft: 0 * DP,
 		backgroundColor: 'white',
 	},
 });

--- a/src/component/templete/community/ArticleDetail.js
+++ b/src/component/templete/community/ArticleDetail.js
@@ -1,18 +1,7 @@
 import React from 'react';
 import {txt} from 'Root/config/textstyle';
-import {
-	FlatList,
-	Platform,
-	StyleSheet,
-	Text,
-	TouchableOpacity,
-	View,
-	ScrollView,
-	ActivityIndicator,
-	Keyboard,
-	KeyboardAvoidingView,
-} from 'react-native';
-import DP from 'Root/config/dp';
+import {FlatList, Platform, StyleSheet, Text, TouchableOpacity, View, ActivityIndicator, Keyboard} from 'react-native';
+import DP, {isNotch} from 'Root/config/dp';
 import {BLACK, GRAY10, GRAY20, GRAY40, WHITE} from 'Root/config/color';
 import Modal from 'Root/component/modal/Modal';
 import Article from 'Root/component/organism/article/Article';
@@ -31,6 +20,7 @@ import ParentComment from 'Root/component/organism/comment/ParentComment';
 import ReplyWriteBox from 'Root/component/organism/input/ReplyWriteBox';
 import {useKeyboardBottom} from 'Root/component/molecules/input/usekeyboardbottom';
 import {count_to_K} from 'Root/util/stringutil';
+import comment_obj from 'Root/config/comment_obj';
 /**
  * 자유게시글 상세 내용
  * @param {object} props - Props Object
@@ -195,134 +185,142 @@ export default ArticleDetail = props => {
 			});
 		} else {
 			if (editData.comment_contents.trim() == '') return Modal.popOneBtn('댓글을 입력하세요.', '확인', () => Modal.close());
-			Modal.popLoading(true);
-			let param = {
-				comment_contents: editData.comment_contents, //내용
-				comment_is_secure: privateComment, //공개여부 테스트때 반영
-				community_object_id: data._id,
-			};
-			if (editData.comment_photo_uri && editData.comment_photo_uri.length > 0) {
-				param.comment_photo_uri = editData.comment_photo_uri;
-			} else {
-				param.comment_photo_remove = true;
-			}
-			param.comment_photo_uri = editData.comment_photo_uri == '' ? 'https:// ' : editData.comment_photo_uri;
-
-			if (parentComment) {
-				//대댓글일 경우 해당 부모 댓글에 대한 댓글을 추가
-				param = {...param, commentobject_id: parentComment._id};
-			} else {
-				//부모댓글에 쓰는 경우가 아니라면 community 게시글에 대한 댓글을 추가
-				param = {...param, community_object_id: data._id};
-			}
-
-			//댓글 수정을 확정
-			if (editMode) {
-				let whichComment = comments.findIndex(v => v._id == editData._id) == -1 ? '' : comments.findIndex(v => v._id == editData._id); //부모댓글
-				updateComment(
-					{
-						...param,
-						commentobject_id: editData._id,
-						// comment_photo_remove: !editData.comment_photo_uri || editData.comment_photo_uri == 0,
-					},
-					result => {
-						// console.log(result);
-						setParentComment();
-						setEditData({
-							comment_contents: '',
-							comment_photo_uri: '',
-						});
-						getCommentListByCommunityId(
-							{
-								community_object_id: data._id,
-								request_number: 1000,
-							},
-							comments => {
-								!parentComment && setComments([]); //댓글목록 초기화
-								let res = comments.msg.filter(e => !e.comment_is_delete || e.children_count != 0);
-								let dummyForBox = res[res.length - 1];
-								if (editData.parent != undefined && editData.children_count == 0) {
-									res.map((v, i) => {
-										res[i].isEdited = i == editData.parent ? true : false;
-									});
-								} else {
-									res.map((v, i) => {
-										res[i].isEdited = false;
-									});
-								}
-								res.push(dummyForBox);
-								setComments(res);
-								parentComment && addChildCommentFn.current();
-								setPrivateComment(false);
-								setEditMode(false);
-								Modal.close();
-								setTimeout(() => {
-									flatListRef.current.scrollToIndex({
-										animated: true,
-										index: whichComment == '' ? editData.parent : whichComment ? whichComment : 0,
-										viewPosition: 0,
-									});
-								}, 500);
-							},
-							err => {
-								console.log('getCommentListByCommunityId', err);
-								if (err.includes('검색 결과가 없습니다.')) {
-									setComments([{}]);
-								}
-							},
-						);
-					},
-					err => Modal.alert(err),
-				);
-			} else {
-				let whichParent = '';
-				if (parentComment) {
-					whichParent = comments.findIndex(e => e._id == param.commentobject_id);
+			// Modal.popLoading(true);
+			try {
+				let param = {
+					comment_contents: editData.comment_contents, //내용
+					comment_is_secure: privateComment, //공개여부 테스트때 반영
+					community_object_id: data._id,
+				};
+				if (editData.comment_photo_uri && editData.comment_photo_uri.length > 0) {
+					param.comment_photo_uri = editData.comment_photo_uri;
+				} else {
+					param.comment_photo_remove = true;
 				}
-				createComment(
-					param,
-					result => {
-						// console.log(result);
-						setParentComment();
-						setEditData({
-							comment_contents: '',
-							comment_photo_uri: '',
-						});
-						getCommentListByCommunityId(
-							{
-								community_object_id: data._id,
-								request_number: 1000,
-							},
-							comments => {
-								!parentComment && setComments([]); //댓글목록 초기화
-								let res = comments.msg.filter(e => !e.comment_is_delete || e.children_count != 0);
-								let dummyForBox = res[res.length - 1];
-								res.push(dummyForBox);
-								setComments(res);
-								parentComment && addChildCommentFn.current();
-								setPrivateComment(false);
-								setEditMode(false); // console.log('comments', comments);
-								Modal.close();
-								setTimeout(() => {
-									whichParent == ''
-										? flatListRef.current.scrollToIndex({animated: true, index: 0, viewPosition: 0.5})
-										: flatListRef.current.scrollToIndex({animated: true, index: whichParent, viewPosition: 0});
-								}, 500);
-								input.current.blur();
-							},
-							err => {
-								console.log('getCommentListByCommunityId', err);
-								if (err == '검색 결과가 없습니다.') {
-									setComments([{}]);
-								}
-							},
-						);
-					},
-					err => {
-						console.log('err', err);
-						Modal.close();
-					},
-				);
+				param.comment_photo_uri = editData.comment_photo_uri == '' ? 'https:// ' : editData.comment_photo_uri;
+
+				if (parentComment) {
+					//대댓글일 경우 해당 부모 댓글에 대한 댓글을 추가
+					param = {...param, commentobject_id: parentComment._id};
+				} else {
+					//부모댓글에 쓰는 경우가 아니라면 community 게시글에 대한 댓글을 추가
+					param = {...param, community_object_id: data._id};
+				}
+
+				//댓글 수정을 확정
+				if (editMode) {
+					let whichComment = comments.findIndex(v => v._id == editData._id) == -1 ? '' : comments.findIndex(v => v._id == editData._id); //부모댓글
+					updateComment(
+						{
+							...param,
+							commentobject_id: editData._id,
+							// comment_photo_remove: !editData.comment_photo_uri || editData.comment_photo_uri == 0,
+						},
+						result => {
+							// console.log(result);
+							setParentComment();
+							setEditData({
+								comment_contents: '',
+								comment_photo_uri: '',
+							});
+							getCommentListByCommunityId(
+								{
+									community_object_id: data._id,
+									request_number: 1000,
+								},
+								comments => {
+									!parentComment && setComments([]); //댓글목록 초기화
+									let res = comments.msg.filter(e => !e.comment_is_delete || e.children_count != 0);
+									let dummyForBox = res[res.length - 1];
+									if (editData.parent != undefined && editData.children_count == 0) {
+										res.map((v, i) => {
+											res[i].isEdited = i == editData.parent ? true : false;
+										});
+									} else {
+										res.map((v, i) => {
+											res[i].isEdited = false;
+										});
+									}
+									res.push(dummyForBox);
+									setComments(res);
+									parentComment && addChildCommentFn.current();
+									setPrivateComment(false);
+									setEditMode(false);
+									Modal.close();
+									setTimeout(() => {
+										flatListRef.current.scrollToIndex({
+											animated: true,
+											index: whichComment == '' ? editData.parent : whichComment ? whichComment : 0,
+											viewPosition: 0,
+										});
+									}, 300);
+								},
+								err => {
+									console.log('getCommentListByCommunityId', err);
+									if (err.includes('검색 결과가 없습니다.')) {
+										setComments([{}]);
+									}
+								},
+							);
+						},
+						err => {
+							Modal.alert(err);
+							console.log('err', err);
+						},
+					);
+				} else {
+					let whichParent = '';
+					if (parentComment) {
+						whichParent = comments.findIndex(e => e._id == param.commentobject_id);
+					}
+					console.log('param', param);
+					createComment(
+						param,
+						result => {
+							// console.log(result);
+							setParentComment();
+							setEditData({
+								comment_contents: '',
+								comment_photo_uri: '',
+							});
+							getCommentListByCommunityId(
+								{
+									community_object_id: data._id,
+									request_number: 1000,
+								},
+								comments => {
+									!parentComment && setComments([]); //댓글목록 초기화
+									let res = comments.msg.filter(e => !e.comment_is_delete || e.children_count != 0);
+									let dummyForBox = res[res.length - 1];
+									res.push(dummyForBox);
+									setComments(res);
+									parentComment && addChildCommentFn.current();
+									setPrivateComment(false);
+									setEditMode(false); // console.log('comments', comments);
+									Modal.close();
+									setTimeout(() => {
+										whichParent == ''
+											? flatListRef.current.scrollToIndex({animated: true, index: 0, viewPosition: 0.5})
+											: flatListRef.current.scrollToIndex({animated: true, index: whichParent, viewPosition: 0});
+									}, 500);
+									// input.current.blur();
+								},
+								err => {
+									console.log('getCommentListByCommunityId', err);
+									if (err == '검색 결과가 없습니다.') {
+										setComments([{}]);
+									}
+								},
+							);
+						},
+						err => {
+							console.log('err', err);
+							Modal.close();
+						},
+					);
+				}
+			} catch (err) {
+				console.log('err', err);
 			}
 		}
 	};
@@ -330,9 +328,9 @@ export default ArticleDetail = props => {
 	const [isReplyFocused, setReplyFocus] = React.useState(false);
 
 	const onFocus = () => {
-		input.current.blur();
+		// input.current.blur();
 		floatInput.current.focus();
-		setReplyFocus(true);
+		// setReplyFocus(true);
 	};
 
 	const onFocus3 = () => {
@@ -340,18 +338,16 @@ export default ArticleDetail = props => {
 	};
 	const onBlur = () => {
 		floatInput.current.focus();
-		setReplyFocus(false);
+		// setReplyFocus(false);
 	};
 
 	const onBlur3 = () => {
 		setReplyFocus(false);
-		if (editMode) {
-			setEditMode(false);
-			setEditData({
-				comment_contents: '',
-				comment_photo_uri: '',
-			});
-		}
+		setEditData({
+			comment_contents: '',
+			comment_photo_uri: '',
+		});
+		setParentComment();
 	};
 
 	// 답글 쓰기 -> 자물쇠버튼 클릭 콜백함수
@@ -373,7 +369,27 @@ export default ArticleDetail = props => {
 	React.useEffect(() => {
 		if (props.route.params.selectedPhoto && props.route.params.selectedPhoto.length > 0) {
 			let selected = props.route.params.selectedPhoto[0];
-			setEditData({...editData, comment_photo_uri: selected.cropUri ?? selected.uri});
+			const checkEdit = comment_obj.editData._id != ''; //전역변수에 저장된 수정데이터가 있을 경우 수정데이터(editData)에 선택한 사진을 저장
+			setEditData({...(checkEdit ? comment_obj.editData : editData), comment_photo_uri: selected.cropUri ?? selected.uri});
+			//전역변수에 저장된 부모댓글 데이터가 있을 경우 부모댓글 다시 지정
+			if (comment_obj.parentComment && comment_obj.parentComment._id != '') {
+				setParentComment(comment_obj.parentComment);
+			}
+			//수정 데이터 전역변수 초기화
+			comment_obj.editData = {
+				comment_contents: '',
+				comment_photo_uri: '',
+				_id: '',
+			};
+			//부모 댓글 데이터 전역변수 초기화
+			comment_obj.parentComment = {
+				comment_contents: '',
+				comment_photo_uri: '',
+				_id: '',
+			};
+			setTimeout(() => {
+				input.current?.focus();
+			}, 200);
 		}
 	}, [props.route.params?.selectedPhoto]);
 
@@ -384,7 +400,9 @@ export default ArticleDetail = props => {
 				navigation.navigate('LoginRequired');
 			});
 		} else {
-			console.log('onAddphoto');
+			// console.log('onAddphoto');
+			editData && editData._id != '' ? (comment_obj.editData = editData) : false;
+			parentComment ? (comment_obj.parentComment = parentComment) : false;
 			props.navigation.push('SinglePhotoSelect', {prev: {name: props.route.name, key: props.route.key}});
 		}
 	};
@@ -407,7 +425,6 @@ export default ArticleDetail = props => {
 			});
 		} else {
 			// console.log('대댓글 쓰기 버튼 클릭 : ', parentCommentId.comment_writer_id.user_nickname);
-			input.current?.focus();
 			setParentComment(parentCommentId);
 			editComment || setEditComment(true);
 			setEditMode(false);
@@ -418,6 +435,9 @@ export default ArticleDetail = props => {
 			addChildCommentFn.current = addChildComment;
 			const findIndex = comments.findIndex(e => e._id == parentCommentId._id);
 			let offset = parentCommentId.comment_photo_uri ? 320 * DP : 0;
+			setTimeout(() => {
+				input.current?.focus();
+			}, 200);
 			scrollTo(findIndex, offset);
 		}
 	};
@@ -427,15 +447,22 @@ export default ArticleDetail = props => {
 		// console.log('수정 데이터', comment);
 		setEditMode(true);
 		setParentComment(); // 수정모드로 전환시 기존의 답글쓰기 데이터 출력 취소
-		const findParentIndex = comments.findIndex(e => e._id == parent); //부모댓글의 인덱스
+		const findParentIndex = comments.findIndex(e => e._id == parent._id); //부모댓글의 인덱스
 		let viewOffset = 0; //자식댓글이 존재할 경우 내려갈 offSet 수치
 		console.log('childIndex', child);
 		if (child.findIndex != undefined && child.findIndex != -1) {
-			viewOffset = 332 * child.hasPhoto + 110 * (child.findIndex + 1) * DP;
+			viewOffset = 160 * (child.findIndex + 1) * DP;
+			viewOffset = viewOffset + 540 * child.hasPhoto * DP;
+			comment.comment_photo_uri ? (viewOffset = viewOffset + 360 * DP) : false;
+		}
+		if (parent.comment_photo_uri) {
+			Platform.OS == 'android' ? (viewOffset = viewOffset + 400 * DP) : (viewOffset = viewOffset + 440 * DP);
 		}
 		setEditData({...comment, parent: findParentIndex});
 		setPrivateComment(comment.comment_is_secure);
-		input.current?.focus();
+		setTimeout(() => {
+			input.current?.focus();
+		}, 500);
 		scrollTo(findParentIndex, viewOffset);
 	};
 
@@ -453,16 +480,6 @@ export default ArticleDetail = props => {
 			},
 			Platform.OS == 'android' ? 300 : 0,
 		);
-	};
-
-	//수정이나 답글쓰기 눌렀을 때 스크롤 함수
-	const scrollToReplyBox = () => {
-		if (Platform.OS == 'android') {
-			// console.log('comments.length - 1', comments.length - 1);
-			flatListRef.current.scrollToIndex({animated: true, index: comments.length - 1, viewPosition: 1, viewOffset: 0});
-		} else {
-			flatListRef.current.scrollToIndex({animated: false, index: comments.length - 1, viewPosition: 0.5, viewOffset: 0});
-		}
 	};
 
 	//답글 더보기 클릭
@@ -679,7 +696,6 @@ export default ArticleDetail = props => {
 	};
 
 	const renderItem = ({item, index}) => {
-		// console.log('comments.length ', comments.length);
 		//수정 혹은 답글쓰기 때, 대상 부모 댓글의 배경색을 바꾸는 함수
 		const getBgColor = () => {
 			let result = WHITE;
@@ -696,7 +712,7 @@ export default ArticleDetail = props => {
 					{comments.length == 1 && (
 						<Text style={[txt.roboto26, {color: GRAY20, paddingVertical: 20 * DP, textAlign: 'center'}]}>댓글이 없습니다.</Text>
 					)}
-					<View style={[{marginTop: 0 * DP, marginBottom: 10 * DP, opacity: key > 0 || isReplyFocused ? 0 : 1}]}>
+					<View style={[{marginBottom: 10 * DP, opacity: key > 0 || isReplyFocused ? 0 : 1}]}>
 						<ReplyWriteBox
 							onAddPhoto={onAddPhoto}
 							onChangeReplyInput={onChangeReplyInput}
@@ -719,7 +735,7 @@ export default ArticleDetail = props => {
 			);
 		} else
 			return (
-				<View style={[style.commentContainer, {}]} key={item._id} onLayout={onLayoutCommentList}>
+				<View style={[style.commentContainer, {backgroundColor: getBgColor()}]} key={item._id} onLayout={onLayoutCommentList}>
 					<ParentComment
 						parentComment={item}
 						onPressReplyBtn={onReplyBtnClick} // 부모 댓글의 답글쓰기 클릭 이벤트
@@ -729,17 +745,6 @@ export default ArticleDetail = props => {
 						showChild={() => showChild(index)}
 						editData={editData}
 					/>
-					{(editMode && editData.parent == index && editData._id == item._id) ||
-						(parentComment && parentComment._id == item._id && (
-							<View
-								style={{
-									position: 'absolute',
-									backgroundColor: getBgColor(),
-									width: '100%',
-									height: item.comment_photo_uri ? 820 * DP : 220 * DP,
-									zIndex: -1,
-								}}></View>
-						))}
 				</View>
 			);
 	};
@@ -814,7 +819,7 @@ const style = StyleSheet.create({
 		marginTop: 10 * DP,
 	},
 	commentContainer: {
-		paddingBottom: 10 * DP,
+		// paddingBottom: 10 * DP,
 		paddingTop: 20 * DP,
 		alignItems: 'center',
 		// backgroundColor: 'yellow',

--- a/src/component/templete/feed/FeedList.js
+++ b/src/component/templete/feed/FeedList.js
@@ -379,10 +379,10 @@ export default FeedList = ({route, navigation}) => {
 				let params = {
 					login_userobject_id: userGlobalObject.userInfo._id,
 					limit: FEED_LIMIT,
-					order_value: pre ? 'pre' : 'next',
 				};
 				if (feedList.length > 0) {
 					params.target_object_id = pre ? feedList[0]._id : feedList[feedList.length - 1]._id;
+					params.order_value = pre ? 'pre' : 'next';
 				}
 				console.log('params', params);
 				getSuggestFeedList(

--- a/src/component/templete/feed/ReportForm.js
+++ b/src/component/templete/feed/ReportForm.js
@@ -27,8 +27,8 @@ export default ReportForm = props => {
 
 	const route = useRoute();
 	const navigation = useNavigation();
-	const [city, setCity] = React.useState(['광역시, 도']); //광역시도 API자료 컨테이너
-	const [district, setDistrict] = React.useState(['시군 선택']); //시군 API자료 컨테이너
+	const [city, setCity] = React.useState(['시, 도']); //광역시도 API자료 컨테이너
+	const [district, setDistrict] = React.useState(['시,군,구']); //시군 API자료 컨테이너
 	const [isDistrictChanged, setIsDistrictChanged] = React.useState(false); // 시군 선택되었는지 여부
 	const [neighbor, setNeighbor] = React.useState(['동읍면']); //동읍면 API 자료 컨테이너
 	const [isSpeciesChanged, setIsSpeciesChanged] = React.useState(false);
@@ -377,7 +377,7 @@ export default ReportForm = props => {
 						</View>
 						<View style={[{flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 10 * DP, marginBottom: 20 * DP}]}>
 							<TouchableOpacity onPress={onPressCity} style={[reportStyle.dropdownSelect_depth1, {width: 268 * DP}]}>
-								<View style={[reportStyle.missing_location_container]}>
+								<View style={[reportStyle.missing_location_container, {}]}>
 									<Text style={[txt.noto28, reportStyle.missing_location]}>{data.report_location.city}</Text>
 									<Arrow_Down_BLACK />
 								</View>
@@ -433,15 +433,19 @@ const reportStyle = StyleSheet.create({
 		// marginLeft: 12 * DP,
 		borderRadius: 30 * DP,
 		justifyContent: 'center',
+		alignItems: 'center',
 		backgroundColor: GRAY50,
 	},
 	missing_location_container: {
 		flexDirection: 'row',
 		alignItems: 'center',
-		justifyContent: 'space-around',
+		// justifyContent: 'center',
+		// justifyContent: 'space-around',
 	},
 	missing_location: {
 		height: 44 * DP,
+		// backgroundColor: 'red',
+		minWidth: 160 * DP,
 		textAlign: 'center',
 	},
 });

--- a/src/component/templete/list/AlarmList.js
+++ b/src/component/templete/list/AlarmList.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {FlatList, ScrollView, Text, View, StyleSheet, SafeAreaView, ActivityIndicator, RefreshControl} from 'react-native';
-import UserAccount from 'Organism/listitem/UserAccount';
 import {accountHashList} from 'Organism/style_organism copy';
 import UserNote from '../../organism/listitem/UserNote';
 import DailyAlarm from '../../organism/list/DailyAlarm';

--- a/src/component/templete/media/AddPhoto.js
+++ b/src/component/templete/media/AddPhoto.js
@@ -139,7 +139,7 @@ export default AddPhoto = props => {
 			.then(album => {
 				setPhotoList([...album.edges]);
 				// setPhotoList(album.edges);
-				console.log(album);
+				// console.log(album);
 			})
 			.catch(err => {
 				console.log('cameraroll error===>' + err);
@@ -204,7 +204,7 @@ export default AddPhoto = props => {
 	}, [selectedPhoto]);
 
 	React.useEffect(() => {
-		console.log('selectedPhoto', props.route.params);
+		// console.log('selectedPhoto', props.route.params);
 		if (props.route.params.selectedPhoto && props.route.params.selectedPhoto.length > 0) {
 			setSelectedPhoto(props.route.params.selectedPhoto);
 		}

--- a/src/component/templete/missing/ReportDetail.js
+++ b/src/component/templete/missing/ReportDetail.js
@@ -286,25 +286,7 @@ export default ReportDetail = props => {
 		navigation.push('FeedCommentList', {feedobject: data, edit: comment}); // 수정하려는 댓글 정보를 포함해서 보냄
 	};
 
-	const [showImgMode, setShowImgMode] = React.useState(false);
-	const backAction = () => {
-		console.log('back', showImgMode);
-		if (showImgMode) {
-			Modal.close();
-			setShowImgMode(false);
-			return true;
-		} else {
-			return false;
-		}
-	};
-
-	React.useEffect(() => {
-		BackHandler.addEventListener('hardwareBackPress', backAction);
-		return () => BackHandler.removeEventListener('hardwareBackPress', backAction);
-	}, [showImgMode]);
-
 	const onPressReqeustPhoto = () => {
-		setShowImgMode(true);
 		Modal.popPhotoListViewModal(
 			data.feed_medias.map(v => v.media_uri),
 			() => Modal.close(),

--- a/src/component/templete/protection/AnimalProtectRequestDetail.js
+++ b/src/component/templete/protection/AnimalProtectRequestDetail.js
@@ -1,6 +1,6 @@
 import {useNavigation} from '@react-navigation/core';
 import React from 'react';
-import {Text, TouchableOpacity, View, FlatList, Platform, StyleSheet, BackHandler} from 'react-native';
+import {Text, TouchableOpacity, View, FlatList, Platform, StyleSheet} from 'react-native';
 import {btn_w276} from 'Atom/btn/btn_style';
 import AniButton from 'Root/component/molecules/button/AniButton';
 import RescueImage from 'Root/component/molecules/image/RescueImage';
@@ -214,27 +214,8 @@ export default AnimalProtectRequestDetail = ({route}) => {
 		);
 	};
 
-	const [showImgMode, setShowImgMode] = React.useState(false);
-	const backAction = () => {
-		console.log('back', showImgMode);
-		if (showImgMode) {
-			Modal.close();
-			setShowImgMode(false);
-			return true;
-		} else {
-			return false;
-		}
-	};
-
-	React.useEffect(() => {
-		BackHandler.addEventListener('hardwareBackPress', backAction);
-		return () => BackHandler.removeEventListener('hardwareBackPress', backAction);
-	}, [showImgMode]);
-
 	//사진 썸네일 클릭
 	const onPressReqeustPhoto = () => {
-		console.log('v', data.protect_request_photos_uri);
-		setShowImgMode(true);
 		Modal.popPhotoListViewModal(data.protect_request_photos_uri, () => Modal.close());
 	};
 

--- a/src/component/templete/protection/AssignProtectAnimalImage.js
+++ b/src/component/templete/protection/AssignProtectAnimalImage.js
@@ -36,17 +36,19 @@ export default AssignProtectAnimalImage = props => {
 		navigation.push('AssignProtectAnimalDate', data);
 	};
 
-	React.useEffect(()=>{
-		if(props.route.params?.selectedPhoto&&props.route.params.selectedPhoto.length>0){
+	React.useEffect(() => {
+		if (props.route.params?.selectedPhoto && props.route.params.selectedPhoto.length > 0) {
 			let selected = props.route.params.selectedPhoto;
-			let photoList = selected.map(v=>{return v.cropUri??v.uri});
+			let photoList = selected.map(v => {
+				return v.cropUri ?? v.uri;
+			});
 			setImageList(photoList);
 			setData({...data, protect_animal_photo_uri_list: photoList || data.protect_animal_photo_uri_list});
 		}
-	},[props.route.params?.selectedPhoto]);
+	}, [props.route.params?.selectedPhoto]);
 
 	const gotoSelectPicture = () => {
-		props.navigation.push("MultiPhotoSelect",{prev:{name:props.route.name,key:props.route.key}});
+		props.navigation.push('MultiPhotoSelect', {prev: {name: props.route.name, key: props.route.key}});
 	};
 
 	return (

--- a/src/component/templete/protection/ProtectCommentList.js
+++ b/src/component/templete/protection/ProtectCommentList.js
@@ -277,7 +277,7 @@ export default ProtectCommentList = props => {
 	//미트볼, 수정을 누르면 동작
 	const onEdit = (comment, parent) => {
 		// console.log('수정 데이터', comment.comment_is_secure);
-		const findParentIndex = comments.findIndex(e => e._id == parent);
+		const findParentIndex = comments.findIndex(e => e._id == parent._id);
 		setEditMode(true);
 		setPrivateComment(comment.comment_is_secure);
 		setParentComment(); // 수정모드로 전환시
@@ -285,6 +285,7 @@ export default ProtectCommentList = props => {
 		setTimeout(() => {
 			input.current.focus();
 		}, 200);
+		console.log('findParentIndex', findParentIndex);
 		scrollToReply(findParentIndex);
 	};
 
@@ -394,7 +395,7 @@ export default ProtectCommentList = props => {
 			return result;
 		};
 		return (
-			<View style={[feedCommentList.commentContainer, {backgroundColor: getBgColor(), alignItems: 'center', width: 750 * DP}]} key={item._id}>
+			<View style={[style.commentContainer, {backgroundColor: getBgColor(), alignItems: 'center', width: 750 * DP}]} key={item._id}>
 				<ParentComment
 					parentComment={item}
 					onPressReplyBtn={onReplyBtnClick} // 부모 댓글의 답글쓰기 클릭 이벤트
@@ -475,7 +476,7 @@ const style = StyleSheet.create({
 		width: 750 * DP,
 		alignSelf: 'center',
 		alignItems: 'center',
-		marginBottom: 20 * DP,
+		marginBottom: 10 * DP,
 		// backgroundColor: 'lightblue',
 	},
 	cotent_container_header: {
@@ -490,5 +491,11 @@ const style = StyleSheet.create({
 	cotent_container_info: {
 		width: 694 * DP,
 		marginBottom: 20 * DP,
+	},
+	commentContainer: {
+		paddingBottom: 10 * DP,
+		paddingTop: 20 * DP,
+		alignItems: 'center',
+		// backgroundColor: 'yellow',
 	},
 });

--- a/src/component/templete/search/SearchAccountA.js
+++ b/src/component/templete/search/SearchAccountA.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FlatList, ScrollView, StyleSheet, Text, View} from 'react-native';
+import {FlatList, ScrollView, StyleSheet, Text, TouchableOpacity, View} from 'react-native';
 import ControllableAccountList from 'Organism/list/ControllableAccountList';
 import {followUser, unFollowUser} from 'Root/api/userapi';
 import Modal from 'Root/component/modal/Modal';
@@ -48,14 +48,16 @@ export default SearchAccountA = React.memo((props, ref) => {
 
 	const renderItem = ({item, index}) => {
 		return (
-			<ControllableAccount
-				data={item}
-				showCrossMark={false}
-				showButtons={false}
-				onClickLabel={() => onClickAccount(item, index)}
-				// onClickFollowBtn={() => onClickFollowBtn(item)}
-				// onClickUnFollowBtn={() => onClickUnFollowBtn(item)}
-			/>
+			<TouchableOpacity onPress={() => onClickAccount(item, index)} activeOpacity={0.8}>
+				<ControllableAccount
+					data={item}
+					showCrossMark={false}
+					showButtons={false}
+					onClickLabel={() => onClickAccount(item, index)}
+					// onClickFollowBtn={() => onClickFollowBtn(item)}
+					// onClickUnFollowBtn={() => onClickUnFollowBtn(item)}
+				/>
+			</TouchableOpacity>
 		);
 	};
 

--- a/src/config/comment_obj.js
+++ b/src/config/comment_obj.js
@@ -1,0 +1,12 @@
+export default comment_obj = {
+	editData: {
+		comment_contents: '',
+		comment_photo_uri: '',
+		_id: '',
+	},
+	parentComment: {
+		comment_contents: '',
+		comment_photo_uri: '',
+		_id: '',
+	},
+};

--- a/src/i18n/msg.js
+++ b/src/i18n/msg.js
@@ -368,7 +368,7 @@ export const MANAGEMENT_OF_VOLUNTEER = '봉사활동 신청관리';
 export const FAVORITES = '즐겨찾기';
 export const FRIENDS = '친구';
 export const PEED_CONTENTS = '피드 게시글';
-export const REQ_PROTECTION_SAVE = '보호요청(저장)';
+export const REQ_PROTECTION_SAVE = '동물보호';
 export const COMUNITY = '커뮤니티';
 
 export const MY_ACTIVITY_IN_SHELTER = '나의 활동';
@@ -386,7 +386,7 @@ export const INFO_QUESTION = '정보/문의';
 //User Menu 버튼
 export const INFO = '알림';
 export const ANIMAL_PROTECTION_STATE = '동물 보호 현황';
-export const PROTECTION_REQUEST = '보호 요청(저장)';
+export const PROTECTION_REQUEST = '동물보호';
 
 export const PLEASE_UPLOAD_PIC = '해당 동물의 특징이 잘 보이는 이미지를 올려주세요.';
 export const PLEASE_GIVE_ME_DATE_AND_PLACE = '해당 동물이 구조된 날짜와 장소를 알려 주세요.';

--- a/src/navigation/header/ProfileHeader.js
+++ b/src/navigation/header/ProfileHeader.js
@@ -28,7 +28,11 @@ export default ProfileHeader = props => {
 			setTimeout(() => {
 				if (data.user_type == 'shelter' && !data.user_contacted) {
 					Modal.alert(NOT_REGISTERED_SHELTER);
-				} else
+				} else if (userGlobalObject.userInfo.isPreviewMode) {
+					Modal.popLoginRequestModal(() => {
+						navigation.navigate('LoginRequired');
+					});
+				} else {
 					Modal.popMessageModal(
 						data.user_nickname,
 						msg => {
@@ -47,6 +51,7 @@ export default ProfileHeader = props => {
 						},
 						() => alert('나가기'),
 					);
+				}
 			}, 100);
 		} else if (select.includes('님의 관심사')) {
 			Modal.close();


### PR DESCRIPTION
*수정 사항:
*수정 결과: 
*수정 파일: 
1) src/component/molecules/input/HashInput.js
- 피드 글쓰기 박스가 클릭 시 포커싱이 안되던 현상 수정 
- 피드 위치 추가 시 출력되던 텍스트의 maxWidth가 지나치게 짧던 현상 수정
- 태그 및 해쉬 검색 시 출력되는 컴포넌트의 너비가 '100%'로 되어 하단 컴포넌트에도 영향을 끼치던 현상 수정

2) 사진 자세히 보기 모달(PhotoListViewModal)이 열린 상태에서 하드웨어 Back버튼 클릭 시 페이지가 뒤로 가지던 문제 
     처리 방법 개선
- src/component/molecules/media/FeedMedia.js
- src/component/molecules/modal/PhotoListViewModal.js
- src/component/organism/article/ArticleContent.js
- src/component/templete/missing/ReportDetail.js
- src/component/templete/protection/AnimalProtectRequestDetail.js

3) src/component/molecules/modal/ReviewFilterModal.js
- 리뷰 필터 모달에서 광역시,도 선택 시 자동으로 시,군,구가 바뀌지 않도록 수정
- 광역시,도만 선택 상태로 검색이 가능하도록 처리

4) src/component/organism/comment/ChildComment.js
- 자식 댓글의 사진 클릭 시 PhotoListViewModal 열리도록 수정

5) src/component/organism/comment/ChildCommentList.js
- 자식 댓글 수정 시 대상 댓글의 배경색이 바뀌는 기능의 스타일 적용 개선(전체 너비가 바뀌도록)

6-1) src/component/organism/comment/ParentComment.js
     src/component/templete/community/ArticleDetail.js
     src/config/comment_obj.js
- 자식 댓글을 수정하거나 삭제한 이후 자식 댓글 리스트가 자동으로 열리도록 처리
- 자식 댓글 수정 시 수정 대상 댓글 영역으로 스크롤 되도록 index 및 offset정보도 넘기도록 수정
- 부모 댓글의 사진 클릭 시 PhotoListViewModal 열리도록 수정
- 댓글의 수정 및 답글 쓰기 상태에서 사진추가 시 해당 상태가 해제되던 현상 수정
- 댓글 포커스 시 두 번 깜빡거리던 현상 수정
- 답글 쓰기, 댓글 수정하기 상태에서 키보드 Blur 시 해당 상태가 해제되도록 처리(커뮤니티 상세페이지에서만 적용)
- 부모 댓글 수정 시 대상 댓글의 배경색이 바뀌는 기능의 스타일 적용 개선(전체 너비가 바뀌도록)

6-2) src/component/templete/community/ReviewDetail.js
- 자유게시글과 같은 방식으로 전환 중 (미완료)

7) src/component/organism/feed/FeedContent.js
- 피드 미트볼을 통한 쪽지보내기가 비로그인 상태에서도 가능하던 현상 수정

8) src/component/organism/input/ReplyWriteBox.js
- 대댓글 쓰기 시 출력되는 ~~님에게 컴포넌트가 지나치게 넓게 출력되던 현상 수정

9) 불필요 코드 제거
- src/component/organism/list/NoteList.js
- src/component/organism/list/NoteMessageList.js
- src/component/organism/listitem/OneAlarm.js
- src/component/organism/listitem/OneMessage.js
- src/component/organism/listitem/OneMessage.js
- src/component/organism/listitem/UserNote.js
- src/component/templete/list/AlarmList.js

10) src/component/organism/listitem/UserAccount.js
- 피드글쓰기의 @태그하기 시 출력되는 유저리스트에 '팔로우중' 마크가 출력되도록 수정

11) src/component/templete/feed/FeedList.js
- 피드 메인 페이지에서 첫 페이지임에도 order_value 필드가 'next'로 되어있던 현상 수정

12) src/component/templete/feed/ReportForm.js
- 제보글쓰기의 Default Text UI 4차에 맞게 조정

13) src/component/templete/search/SearchAccountA.js
- 검색탭에서 계정 클릭 시 닉네임이나 사진을 클릭해야만 프로필로 이동이 되던 현상 수정(우측의 빈 영역도 터치 영역으로 지정)

