### PR TITLE
[하늘] iOS 사진 퍼미션 단계 추가, 관련 설정(plist) 변경

### DIFF
--- a/ios/anilog/Info.plist
+++ b/ios/anilog/Info.plist
@@ -43,7 +43,7 @@
 		</dict>
 	</dict>
 	<key>NSCameraUsageDescription</key>
-	<string>YOUR TEXT</string>
+	<string>서비스 동작을 위해 카메라 접근 권한이 필요합니다.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>서비스 동작을 위해 위치 정보가 필요합니다</string>
 	<key>NSLocationAlwaysUsageDescription</key>
@@ -51,9 +51,9 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>서비스 동작을 위해 위치 정보가 필요합니다</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>YOUR TEXT</string>
+	<string>서비스 동작을 위해 사진 접근 권한이 필요합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>YOUR TEXT</string>
+	<string>서비스 동작을 위해 사진 접근 권한이 필요합니다.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>NotoSansKR-Bold.otf</string>
@@ -89,6 +89,5 @@
 	<false/>
 	<key>CodePushDeploymentKey</key>
 	<string>$(CODEPUSH_KEY)</string>
-
 </dict>
 </plist>

--- a/src/module/PermissionIos.js
+++ b/src/module/PermissionIos.js
@@ -71,7 +71,7 @@ class PermissionIos {
     static getDefaultAlertParams():AlertParams{
         return {
             title: "",
-            msg: "갤러리에 접근하려면 '갤러리' 접근 권한을 허용해야 합니다.",
+            msg: "사진에 접근하려면 '사진/비디오' 접근 권한을 허용해야 합니다.",
             okFunc: PermissionIos.openSetting,
             cancelFunc: null,
             okBtnLabel: "설정",


### PR DESCRIPTION
*수정 사항: 사진추가 버튼 클릭 시 iOS 퍼미션 팝업 뜨도록 추가
*수정 결과: iOS 퍼미션 루틴 작동
*수정 파일:
- ./ios/anilog/info.plist : 최초 권한 요청 시 뜨는 팝업 메시지 변경
- ./media/AddPhoto.js : line 166 함수. iOS 권한 요청 로직 추가됨
- ./module/PermissionIos.js : line 74 멘트. 기본 팝업 메시지 변경
