### PR TITLE
[상우] 실종게시글 사진 추가 시 앱 강제종료 현상수정

### DIFF
--- a/src/component/molecules/calendar/calendar.js
+++ b/src/component/molecules/calendar/calendar.js
@@ -6,7 +6,7 @@ import moment from 'moment';
 import DP from 'Root/config/dp';
 import {day} from 'Root/i18n/msg';
 import {txt} from 'Root/config/textstyle';
-import {APRI10, BLACK, GRAY10, GRAY20, GRAY30, WHITE} from 'Root/config/color';
+import {APRI10, BLACK, GRAY10, GRAY20, GRAY30, GRAY50, WHITE} from 'Root/config/color';
 import {ArrowMarkForCalendar, NextMark} from 'Root/component/atom/icon';
 import YearDropDown from 'Molecules/dropdown/YearDropDown';
 import AniButton from 'Molecules/button/AniButton';
@@ -279,7 +279,22 @@ const Calendar = props => {
 				{/* 하단 나가기 버튼 */}
 				<View style={[styles.btnCont]}>
 					<AniButton btnTitle={'취소'} btnStyle={'border'} btnLayout={{width: 136 * DP, borderRadius: 40 * DP, height: 70 * DP}} onPress={modalOff} />
-					<AniButton btnTitle={'완료'} btnLayout={{width: 136 * DP, borderRadius: 40 * DP, height: 70 * DP}} onPress={onPressConfirm} />
+					{selectedDate == '' ? (
+						<View
+							style={{
+								width: 136 * DP,
+								borderRadius: 40 * DP,
+								height: 70 * DP,
+								borderColor: GRAY30,
+								borderWidth: 2 * DP,
+								alignItems: 'center',
+								justifyContent: 'center',
+							}}>
+							<Text style={[txt.noto26, {color: GRAY20}]}>완료</Text>
+						</View>
+					) : (
+						<AniButton btnTitle={'완료'} btnLayout={{width: 136 * DP, borderRadius: 40 * DP, height: 70 * DP}} onPress={onPressConfirm} />
+					)}
 				</View>
 			</TouchableOpacity>
 		</TouchableOpacity>

--- a/src/component/organism/list/SelectedMediaList.js
+++ b/src/component/organism/list/SelectedMediaList.js
@@ -12,21 +12,26 @@ import {selectedMediaList} from 'Organism/style_organism copy';
  * }} props
  */
 export default SelectedMediaList = props => {
-	const isContainVideo = props.mediaList.length>0;
+	const isContainVideo = props.mediaList.length > 0;
 	const onDelete = index => {
 		props.onDelete(index);
 	};
 	const renderItem = ({item, index}) => {
 		return (
-			<View style={[selectedMediaList.itemContainer,{borderRadius:30*DP}]}>
-				<SelectedMedia layout={props.layout} media={isContainVideo?item:false} media_uri={item} onDelete={() => onDelete(index)}/>
+			<View style={[selectedMediaList.itemContainer, {borderRadius: 30 * DP}]}>
+				<SelectedMedia layout={props.layout} media={isContainVideo ? item : false} media_uri={item} onDelete={() => onDelete(index)} />
 			</View>
 		);
 	};
-	
+
 	return (
-		<View style={{height:props.layout.height}}>
-			<FlatList data={isContainVideo?props.mediaList:props.items} renderItem={renderItem} horizontal={true} showsHorizontalScrollIndicator={false} />
+		<View style={{height: props.layout.height}}>
+			<FlatList
+				data={isContainVideo ? props.mediaList : props.items}
+				renderItem={renderItem}
+				horizontal={true}
+				showsHorizontalScrollIndicator={false}
+			/>
 		</View>
 	);
 };

--- a/src/component/organism/listitem/MissingReportBox .js
+++ b/src/component/organism/listitem/MissingReportBox .js
@@ -19,6 +19,7 @@ const MissingReportBox = props => {
 	const [objCity, setObjCity] = React.useState('');
 	const navigation = useNavigation();
 	// console.log(moment(props.data?.missing_animal_date).format('YY.MM.DD'));
+
 	React.useEffect(() => {
 		try {
 			let objCitys = JSON.parse(`${props.data?.missing_animal_lost_location}`);
@@ -27,23 +28,12 @@ const MissingReportBox = props => {
 			// console.log('err', err);
 		}
 	}, []);
+
 	const onLabelClick = () => {
 		let sexValue = '';
 		switch (props.data.feed_type) {
 			case 'missing':
-				switch (props.data.missing_animal_sex) {
-					case 'male':
-						sexValue = '남';
-						break;
-					case 'female':
-						sexValue = '여';
-						break;
-					case 'unknown':
-						sexValue = '성별모름';
-						break;
-				}
-				const titleValue = props.data.missing_animal_species + '/' + props.data.missing_animal_species_detail + '/' + sexValue;
-				navigation.navigate('MissingAnimalDetail', {title: titleValue, _id: props.data._id});
+				navigation.navigate('MissingAnimalDetail', {title: '', _id: props.data._id, from: 'feedList'});
 				break;
 			case 'report':
 				navigation.navigate('ReportDetail', {_id: props.data._id});

--- a/src/component/templete/feed/FeedWrite.js
+++ b/src/component/templete/feed/FeedWrite.js
@@ -51,14 +51,15 @@ export default FeedWrite = props => {
 		console.log('정보 변경', selectedImg);
 		if (props.route.name != 'FeedEdit') {
 			const param = props.route.params;
-			console.log('param', param);
 			// console.log('param.feed_avatar_id', param.feed_avatar_id);
 			param.feed_avatar_id //피드 글쓰기 클릭시 즉시 작성자 아바타 계정을 선택하는 절차가 추가됨에 따라 분기처리가 필요해짐
 				? // - 유저 계정에서 피드글쓰기를 누른 경우
 				  props.navigation.setParams({
 						...props.route.params,
 						media_uri: selectedImg,
-						feed_medias: selectedImg.map(v => (v ? {media_uri: v.videoUri ?? v.cropUri ?? v.uri, is_video: v.isVideo ?? v.is_video, duration: 0, tags: []} : false)),
+						feed_medias: selectedImg.map(v =>
+							v ? {media_uri: v.videoUri ?? v.cropUri ?? v.uri, is_video: v.isVideo ?? v.is_video, duration: 0, tags: []} : false,
+						),
 						feed_avatar_id: param.feed_avatar_id._id
 							? param.feed_avatar_id._id
 							: param.feed_avatar_id
@@ -69,7 +70,12 @@ export default FeedWrite = props => {
 				  props.navigation.setParams({
 						...props.route.params,
 						media_uri: selectedImg.map(v => v.cropUri ?? v.uri),
-						feed_medias: selectedImg.map(v => ({media_uri: v.videoUri ?? v.cropUri ?? v.uri, is_video: v.isVideo ?? v.is_video, duration: 0, tags: []})),
+						feed_medias: selectedImg.map(v => ({
+							media_uri: v.videoUri ?? v.cropUri ?? v.uri,
+							is_video: v.isVideo ?? v.is_video,
+							duration: 0,
+							tags: [],
+						})),
 						// feed_avatar_id: props.route.params.feed_avatar_id ? props.route.params.feed_avatar_id?._id : userGlobalObject.userInfo._id,
 				  });
 		} else {
@@ -79,7 +85,7 @@ export default FeedWrite = props => {
 				feed_medias: selectedImg.map(img => {
 					let uri = img.videoUri ?? img.cropUri ?? img.uri;
 					let media = props.route.params.feed_medias.find(v => v.media_uri == uri);
-					return {media_uri: uri, is_video: img.isVideo ??img.is_video, duration: 0, tags: media ? media.tags : []};
+					return {media_uri: uri, is_video: img.isVideo ?? img.is_video, duration: 0, tags: media ? media.tags : []};
 				}),
 				photoToDelete: photoToDelete,
 			});
@@ -352,8 +358,12 @@ export default FeedWrite = props => {
 					<SelectedMediaList
 						layout={styles.img_square_round_336}
 						items={selectedImg.map(v => {
-							console.log('selectedImage', v);
+							// console.log('selectedImage', v);
 							return v ? v.cropUri ?? v.uri : undefined;
+						})}
+						mediaList={selectedImg.map(v => {
+							// console.log('selectedImage', v);
+							return v;
 						})}
 						onDelete={deletePhoto}
 					/>
@@ -386,7 +396,7 @@ export default FeedWrite = props => {
 					return v.videoUri ? v.cropUri ?? v.uri : undefined;
 				})}
 				mediaList={selectedImg.map((v, i) => {
-					console.log('media', v)
+					console.log('media', v);
 					return v;
 				})}
 				onDelete={deletePhoto}
@@ -399,8 +409,6 @@ export default FeedWrite = props => {
 	};
 
 	const render = ({item, index}) => {
-		console.log('ahghhhh', props.route.params.feed_public_type);
-
 		return (
 			<View style={[login_style.wrp_main]} ref={container}>
 				{!(showLostAnimalForm || showReportForm) && (

--- a/src/component/templete/list/NewMissingReportList.js
+++ b/src/component/templete/list/NewMissingReportList.js
@@ -22,9 +22,11 @@ const NewMissingReportList = props => {
 		return <MissingReportBox index={index} data={item} />;
 	};
 	let mounted = true;
-	React.useEffect(()=>{
-		return ()=>{mounted=false}
-	},[])
+	React.useEffect(() => {
+		return () => {
+			mounted = false;
+		};
+	}, []);
 
 	React.useEffect(() => {
 		// getList();
@@ -36,7 +38,6 @@ const NewMissingReportList = props => {
 		getList('first');
 		return unsubscribe;
 	}, [navigation]);
-
 
 	// React.useEffect(() => {
 	// 	console.log('두번 눌림', props.doubleTab);
@@ -53,8 +54,8 @@ const NewMissingReportList = props => {
 		getMissingReportList(
 			{...topList, limit: PROTECT_REQUEST_MAIN_LIMIT, page: offset, main_type: true},
 			result => {
-				if(!mounted)return;
-				// console.log('getMissingReportList length', result.msg.length);
+				if (!mounted) return;
+				console.log('getMissingReportList length', result.msg[0]);
 
 				const res = result.msg;
 				if (topList != 'false') {

--- a/src/component/templete/missing/MissingAnimalDetail.js
+++ b/src/component/templete/missing/MissingAnimalDetail.js
@@ -51,11 +51,34 @@ export default MissingAnimalDetail = props => {
 				setData(result);
 				// console.log('data', data.msg);
 				navigation.setParams({writer: data.msg.feed_writer_id._id, isMissingOrReport: true, feed_object: data.msg});
+				if (props.route.params && props.route.params.from == 'feedList') {
+					// console.log('result', result);
+					const getGender = () => {
+						switch (result.missing_animal_sex) {
+							case 'male':
+								return '남아';
+							case 'female':
+								return '여아';
+							case 'unknown':
+								return '';
+							default:
+								break;
+						}
+					};
+					navigation.setOptions({
+						title: `${result.missing_animal_species}/${result.missing_animal_species_detail}${getGender() ? '/' + getGender() : ''}`,
+					});
+				}
 				fetchMissingPostList(result._id);
 			},
 			err => {
 				console.log('getFeedDetailById / Error / MissingAnimalDetail : ', err);
 				if (err.includes('code 500')) {
+					setData('false');
+					setTimeout(() => {
+						Modal.popOneBtn(NETWORK_ERROR, '확인', () => navigation.goBack());
+					}, 500);
+				} else if (err.includes('없습니다')) {
 					setData('false');
 					setTimeout(() => {
 						Modal.popOneBtn(NETWORK_ERROR, '확인', () => navigation.goBack());


### PR DESCRIPTION
*수정 사항: 
*수정 결과:
*수정 파일: 
1) src/component/molecules/calendar/calendar.js
- 달력 모달에서 현재 선택된 날짜가 없을 경우 완료버튼이 비활성 되도록 수정

2) src/component/organism/listitem/MissingReportBox .js
     src/component/templete/missing/MissingAnimalDetail.js
- 피드메인화면 상단의 실종/제보리스트 아이템을 클릭할 시 header의 품종, 상세품종 등이 undefined로 출력되던 현상 수정

3) src/component/templete/feed/FeedWrite.js
- 실종 글쓰기에서 사진추가 시 앱이 강제종료되던 현상 수정

4) src/component/templete/feed/ReportForm.js
- 현재 위치 받아오기 아이콘 클릭 후 '시,군,구' 버튼을 다시 수정하고 싶을 경우 시군구 목록이 출력되지 않던 현상 수정 [미완료 상태]

5)  

