### PR TITLE
[상우] 삭제된 피드가 피드리스트 화면 및 실종/제보 리스트 화면에서 필터가 되도록 적용

### DIFF
--- a/src/component/templete/feed/FeedList.js
+++ b/src/component/templete/feed/FeedList.js
@@ -96,11 +96,14 @@ export default FeedList = ({route}) => {
 	React.useEffect(() => {
 		const unsubscribe = navigation.addListener('focus', () => {
 			setFocused(true);
-			if (feed_obj.deleted_obj) {
+			if (feed_obj.deleted_list && feed_obj.deleted_list.length) {
 				//삭제된 실종,제보 반영
 				try {
-					console.log('feedList when deleted_obj', feedList.length);
-					setFeed(feedList.filter(e => e._id != feed_obj.deleted_obj._id));
+					//삭제된 실종,제보 반영
+					let temp = [...feedList];
+					temp = temp.filter(e => !feed_obj.deleted_list.includes(e._id));
+					// setFeed(feedList.filter(e => e._id != feed_obj.deleted_obj._id));
+					setFeed(temp);
 					feed_obj.deleted_obj = {};
 				} catch (err) {
 					console.log('err', err);
@@ -617,7 +620,6 @@ export default FeedList = ({route}) => {
 	const [testTx, setTx] = React.useState('한');
 	const [code, setCode] = React.useState(62);
 	const viewable = React.useCallback(e => {
-
 		setViewIndex(e.viewableItems[0]?.index);
 	}, []);
 	const separatorComp = React.useCallback(() => {
@@ -646,11 +648,7 @@ export default FeedList = ({route}) => {
 					maxToRenderPerBatch={5}
 					updateCellsBatchingPeriod={10}
 					initialNumToRender={2}
-
 					onEndReachedThreshold={0.3}
-
-
-
 					onEndReached={onEndReached}
 				/>
 			}

--- a/src/component/templete/missing/MissingReportList.js
+++ b/src/component/templete/missing/MissingReportList.js
@@ -28,23 +28,7 @@ export default MissingReportList = props => {
 	const urgentBtnRef = React.useRef();
 
 	React.useEffect(() => {
-		const unsubscribe = navigation.addListener('focus', () => {
-			if (feed_obj.deleted_obj != {}) {
-				try {
-					if (data != 'false') {
-						console.log('feed_obj.deleted_obj', feed_obj.deleted_obj);
-						//삭제된 실종,제보 반영
-						console.log('data', data.length);
-						setData(data.filter(e => e._id != feed_obj.deleted_obj._id));
-						feed_obj.deleted_obj = {};
-					}
-				} catch (err) {
-					console.log('err', err);
-				}
-			}
-		});
 		getList();
-		return unsubscribe;
 	}, []);
 
 	React.useEffect(() => {
@@ -56,8 +40,26 @@ export default MissingReportList = props => {
 					feed_obj.list.push(v);
 				}
 			});
-			console.log('feed_obj.list at MissingReportList', feed_obj.list.length);
 		}
+		const unsubscribe = navigation.addListener('focus', () => {
+			if (feed_obj.deleted_obj._id) {
+				try {
+					console.log('deleted List', feed_obj.deleted_list);
+					//삭제된 실종,제보 반영
+					let temp = [...data];
+					temp = temp.filter(e => !feed_obj.deleted_list.includes(e._id));
+					setData(temp);
+					// setData(data.filter(e => e._id != feed_obj.deleted_obj._id));
+					feed_obj.deleted_obj = {};
+				} catch (err) {
+					console.log('err', err);
+				}
+			}
+		});
+
+		return () => {
+			unsubscribe();
+		};
 	}, [data]);
 
 	const getList = refresh => {

--- a/src/component/templete/protection/AnimalProtectRequestDetail.js
+++ b/src/component/templete/protection/AnimalProtectRequestDetail.js
@@ -444,11 +444,8 @@ export default AnimalProtectRequestDetail = ({route}) => {
 					<FlatList
 						data={removeThis}
 						renderItem={renderOtherRequest}
-						keyExtractor={item => item._id}
-						getItemLayout={(data, index) => {
-							if (!data[index]) return {length: 0, offset: 0, index: index};
-							return {length: ITEM_HEIGHT, offset: ITEM_HEIGHT * index, index: index};
-						}}
+						keyExtractor={keyExtractor}
+						getItemLayout={getItemLayout}
 						style={{backgroundColor: '#fff'}}
 						showsVerticalScrollIndicator={false}
 						ListEmptyComponent={whenEmpty}

--- a/src/component/templete/protection/AnimalProtectRequestDetail.js
+++ b/src/component/templete/protection/AnimalProtectRequestDetail.js
@@ -444,8 +444,11 @@ export default AnimalProtectRequestDetail = ({route}) => {
 					<FlatList
 						data={removeThis}
 						renderItem={renderOtherRequest}
-						keyExtractor={keyExtractor}
-						getItemLayout={getItemLayout}
+						keyExtractor={item => item._id}
+						getItemLayout={(data, index) => {
+							if (!data[index]) return {length: 0, offset: 0, index: index};
+							return {length: ITEM_HEIGHT, offset: ITEM_HEIGHT * index, index: index};
+						}}
 						style={{backgroundColor: '#fff'}}
 						showsVerticalScrollIndicator={false}
 						ListEmptyComponent={whenEmpty}
@@ -468,6 +471,7 @@ export default AnimalProtectRequestDetail = ({route}) => {
 				<FlatList
 					data={comments && comments.length > 2 ? comments.slice(0, 2) : comments}
 					renderItem={renderItem}
+					keyExtractor={item => item._id}
 					ListHeaderComponent={header()}
 					ListFooterComponent={footer()}
 					ListEmptyComponent={<Text style={[txt.roboto28b, {color: GRAY10, paddingVertical: 40 * DP, textAlign: 'center'}]}>댓글이 없습니다.</Text>}

--- a/src/component/templete/protection/ProtectRequestList.js
+++ b/src/component/templete/protection/ProtectRequestList.js
@@ -40,23 +40,6 @@ export default ProtectRequestList = ({route}) => {
 	const flatlist = React.useRef();
 
 	React.useEffect(() => {
-		const unsubscribe = navigation.addListener('focus', () => {
-			// filterRef.current ? false : fetchData(); //포커스마다 새로 fetch를 시도하면 상세글을 갔다가 메인페이지로 돌아와도 기존의 스크롤로 이동을 하지 않음
-			// console.log('리뷰 게시글 전역변수 길이 :  ', community_obj.review.length);
-			if (protect_obj.protect.length > 0) {
-				console.log('protect_obj.protect.length : ', protect_obj.protect.length);
-				// let temp = [...data];
-				// protect_obj.protect.map((v, i) => {
-				// 	console.log('protect_animal_rescue_location', i, v.protect_animal_id.protect_animal_rescue_location);
-				// 	console.log('i', i, v.is_favorite);
-				// });
-				// setData(protect_obj.protect);
-			}
-		});
-		return unsubscribe;
-	}, []);
-
-	React.useEffect(() => {
 		getList(); //필터가 바뀔 때마다 호출되도록 설정
 	}, [filterData]);
 
@@ -113,7 +96,8 @@ export default ProtectRequestList = ({route}) => {
 			params,
 			result => {
 				// console.log('result 첫값 :', result.msg[0].protect_animal_id.protect_animal_rescue_location);
-				console.log('result length  ', result.msg.length);
+				// console.log('result length  ', result.msg.length);
+				console.log('total', result.total_count);
 				let res = result.msg;
 				res.filter(e => e != null); //간헐적으로 오는 null 익셉션 처리
 				//오브젝트 뎁스 일치화 작업

--- a/src/config/feed_obj.js
+++ b/src/config/feed_obj.js
@@ -4,6 +4,7 @@ export default feed_obj = {
 	edit_obj: {},
 	list: [],
 	deleted_obj: {},
+	deleted_list: [],
 	mainHomeFeedList: [],
 	isGpsDenied: false,
 };

--- a/src/config/protect_obj.js
+++ b/src/config/protect_obj.js
@@ -7,13 +7,10 @@ export const updateProtect = (id, bool) => {
 	console.log('id', id, 'bool : ', bool);
 	if (protect_obj.protect.length != 0) {
 		const findIndex = protect_obj.protect.findIndex(e => e._id == id);
-		console.log('updateReview : findIndex', findIndex);
+		console.log('updateProtect : findIndex', findIndex);
 		if (findIndex != -1) {
 			let temp = [...protect_obj.protect];
-			temp[findIndex] = {
-				...temp[findIndex],
-				is_favorite: bool,
-			};
+			temp[findIndex].is_favorite = bool;
 			protect_obj.protect = temp;
 		}
 	}

--- a/src/navigation/header/SimpleWithMeatballHeader.js
+++ b/src/navigation/header/SimpleWithMeatballHeader.js
@@ -24,8 +24,8 @@ export default SimpleWithMeatballHeader = ({route, options, back}) => {
 
 	//즐겨찾기 상태 아이콘 출력인 경우
 	React.useEffect(() => {
-		if (route.params.request_object) {
-			// console.log('route.params.request_object?.protect_request_is_favorite ', route.params.request_object?.protect_request_is_favorite);
+		if (route.params?.request_object) {
+			console.log('route.params.request_object', route.params.request_object?.protect_request_is_favorite);
 			!route.params.request_object?.protect_request_is_favorite ? setFavoriteTag(false) : setFavoriteTag(true);
 		} else if (route.params.feed_object) {
 			// console.log('is_favorite feed_object', route.params.feed_object);
@@ -135,7 +135,7 @@ export default SimpleWithMeatballHeader = ({route, options, back}) => {
 	//제보 실종 미트볼 메뉴 - 삭제 클릭
 	const onPressDeleteFeed = () => {
 		try {
-			// console.log('삭제 제보 실종', route.params._id, route.params?.feed_object.feed_content);
+			// console.log('삭제 제보 실종', route.params._id, route.params?.feed_object);
 			Modal.close();
 			setTimeout(() => {
 				Modal.popTwoBtn(
@@ -153,39 +153,8 @@ export default SimpleWithMeatballHeader = ({route, options, back}) => {
 									// console.log('result / DeleteFeed / SimpleWithMeatballHeader : ', result.msg);
 									Modal.close();
 									feed_obj.deleted_obj = route.params?.feed_object;
+									feed_obj.deleted_list.push(route.params?.feed_object._id);
 									// console.log('navi', JSON.stringify(navigation.getState()));
-									const tr = {
-										stale: false,
-										type: 'stack',
-										key: 'stack-_ualUkbrTqE6NUPyGIfor',
-										index: 1,
-										routes: [
-											{
-												key: 'ProtectionTab-LcAivqJmOGHGN9CrIvv_E',
-												name: 'ProtectionTab',
-												state: {
-													stale: false,
-													type: 'tab',
-													key: 'tab-bTOYiZi04DI7LapZElxqZ',
-													index: 1,
-													routeNames: ['ProtectRequestList', 'MissingReportList'],
-													history: [
-														{type: 'route', key: 'ProtectRequestList-Hfxl85jqWJx4u5C87S13w'},
-														{type: 'route', key: 'MissingReportList-36xWZJypAIw0283zA3DX4'},
-													],
-													routes: [
-														{name: 'ProtectRequestList', key: 'ProtectRequestList-Hfxl85jqWJx4u5C87S13w'},
-														{name: 'MissingReportList', key: 'MissingReportList-36xWZJypAIw0283zA3DX4'},
-													],
-												},
-											},
-											{
-												key: 'ReportDetail-HoRHRtamS7J_z6d9OdoKi',
-												name: 'ReportDetail',
-												params: {},
-											},
-										],
-									};
 									navigation.goBack();
 								},
 								err => {

--- a/src/navigation/route/main_tab/community_stack/CommunityMainStack.js
+++ b/src/navigation/route/main_tab/community_stack/CommunityMainStack.js
@@ -31,6 +31,9 @@ import SocialRelationTopTabNavigation from '../protection_stack/socialRelation_t
 import InputAndSearchHeader from 'Root/navigation/header/InputAndSearchHeader';
 import AddPhoto from 'Root/component/templete/media/AddPhoto';
 import PhotoSelectHeader from 'Root/navigation/header/PhotoSelectHeader';
+import SimpleWithMeatballHeader from 'Root/navigation/header/SimpleWithMeatballHeader';
+import ReportDetail from 'Root/component/templete/missing/ReportDetail';
+import MissingAnimalDetail from 'Root/component/templete/missing/MissingAnimalDetail';
 
 const CommunityMainStackNavi = createStackNavigator();
 
@@ -193,6 +196,16 @@ export default CommunityMainStack = props => {
 				name="UserInfoDetailSetting"
 				component={UserInfoDetailSettting}
 				options={{header: props => <SaveButtonHeader {...props} />, title: '프로필 상세 정보'}}
+			/>
+			<CommunityMainStackNavi.Screen
+				name="ReportDetail"
+				component={ReportDetail}
+				options={{header: props => <SimpleWithMeatballHeader {...props} />}}
+			/>
+			<CommunityMainStackNavi.Screen
+				name="MissingAnimalDetail"
+				component={MissingAnimalDetail}
+				options={{header: props => <SimpleWithMeatballHeader {...props} />}}
 			/>
 		</CommunityMainStackNavi.Navigator>
 	);

--- a/src/navigation/route/main_tab/my_stack/MyStackNavigation.js
+++ b/src/navigation/route/main_tab/my_stack/MyStackNavigation.js
@@ -91,6 +91,8 @@ import OpenSourceDetail from 'Templete/user/OpenSourceDetail';
 import FeedWrite from 'Root/component/templete/feed/FeedWrite';
 import FeedWriteHeader from 'Root/navigation/header/FeedWriteHeader';
 import CommunityEdit from 'Root/component/templete/community/CommunityEdit';
+import ReportDetail from 'Root/component/templete/missing/ReportDetail';
+import MissingAnimalDetail from 'Root/component/templete/missing/MissingAnimalDetail';
 
 const MyStack = createStackNavigator();
 export default MyStackNavigation = props => {
@@ -335,9 +337,7 @@ export default MyStackNavigation = props => {
 			<MyStack.Screen name="SettingOpen" component={SettingOpen} options={{header: props => <SimpleHeader {...props} />, title: '공개 설정'}} />
 			<MyStack.Screen name="ReceivedMessage" component={ReceivedMessage} options={{header: props => <SimpleHeader {...props} />, title: '쪽지함'}} />
 			{/* <MyStack.Screen name="UserNotePage" component={UserNotePage} options={{header: props => <SimpleHeader {...props} />, title: props.title}} /> */}
-
 			<MyStack.Screen name="NoticeList" component={NoticeList} options={{header: props => <SimpleHeader {...props} />, title: '공지사항'}} />
-
 			<MyStack.Screen name="ServiceCenter" component={ServiceCenter} options={{header: props => <SimpleHeader {...props} />, title: '고객 센터'}} />
 			<MyStack.Screen name="CategoryHelp" component={CategoryHelp} options={{header: props => <AlarmAndSearchHeader {...props} />}} />
 			<MyStack.Screen
@@ -424,6 +424,12 @@ export default MyStackNavigation = props => {
 					header: props => <SendHeader {...props} />,
 					title: ' ',
 				})}
+			/>
+			<MyStack.Screen name="ReportDetail" component={ReportDetail} options={{header: props => <SimpleWithMeatballHeader {...props} />}} />
+			<MyStack.Screen
+				name="MissingAnimalDetail"
+				component={MissingAnimalDetail}
+				options={{header: props => <SimpleWithMeatballHeader {...props} />}}
 			/>
 		</MyStack.Navigator>
 	);

--- a/src/navigation/route/search_tab/SearchMainStack.js
+++ b/src/navigation/route/search_tab/SearchMainStack.js
@@ -24,6 +24,9 @@ import ChangePetProfileImage from 'Root/component/templete/pet/ChangePetProfileI
 import ProfileHeader from 'Root/navigation/header/ProfileHeader';
 import AddPhoto from 'Root/component/templete/media/AddPhoto';
 import PhotoSelectHeader from 'Root/navigation/header/PhotoSelectHeader';
+import MissingAnimalDetail from 'Root/component/templete/missing/MissingAnimalDetail';
+import SimpleWithMeatballHeader from 'Root/navigation/header/SimpleWithMeatballHeader';
+import ReportDetail from 'Root/component/templete/missing/ReportDetail';
 
 const SearchStackNav = createStackNavigator();
 
@@ -137,6 +140,12 @@ export default SearchMainStack = props => {
 				options={{header: props => <SimpleHeader {...props} />, title: '보호소 정보 수정'}}
 			/>
 			<SearchStackNav.Screen name="HashFeedList" component={FeedList} options={{header: props => <SimpleHeader {...props} />, title: ''}} />
+			<SearchStackNav.Screen name="ReportDetail" component={ReportDetail} options={{header: props => <SimpleWithMeatballHeader {...props} />}} />
+			<SearchStackNav.Screen
+				name="MissingAnimalDetail"
+				component={MissingAnimalDetail}
+				options={{header: props => <SimpleWithMeatballHeader {...props} />}}
+			/>
 		</SearchStackNav.Navigator>
 	);
 };

--- a/src/navigation/route/search_tab/SearchTabNavigation.js
+++ b/src/navigation/route/search_tab/SearchTabNavigation.js
@@ -142,13 +142,14 @@ export default SearchTabNavigation = props => {
 	};
 
 	const getCommunityList = async () => {
+		console.log('searchContext.searchInfo.searchInput.trimEnd()', searchContext.searchInfo.searchInput.trimEnd());
 		return new Promise(async function (resolve, reject) {
 			try {
 				getSearchCommunityList(
 					{
 						searchKeyword: searchContext.searchInfo.searchInput.trimEnd(),
 						page: 1,
-						limit: REVIEW_LIMIT,
+						limit: 1000,
 					},
 					result => {
 						// console.log('searchContext.searchInfo.searchInput', searchContext.searchInfo.searchInput);


### PR DESCRIPTION
*수정 사항:
*수정 결과
*수정 파일:
1) src/component/templete/feed/FeedList.js
    src/component/templete/missing/MissingReportList.js
- 삭제된 피드가 피드리스트 화면 및 실종/제보 리스트 화면에서 필터가 되도록 적용

2) 특정 스택 스크린에서 제보 및 실종 상세페이지가 지정되어 있지 않아 바텀탭이 출력되지 않던 페이지로 나오던 현상수정
