### PR TITLE
[상우] UI 오류 수정/ 커뮤니티 게시글의 수정 발생 시 갱신 문제 작업

### DIFF
--- a/src/component/molecules/label/ShelterSmallLabel.js
+++ b/src/component/molecules/label/ShelterSmallLabel.js
@@ -43,7 +43,7 @@ const ShelterSmallLabel = props => {
 	};
 
 	return (
-		<View style={{flexDirection: 'row', alignItems: 'center'}}>
+		<TouchableOpacity onPress={onClickLabel} style={{flexDirection: 'row', alignItems: 'center'}}>
 			<TouchableOpacity onPress={onClickLabel}>
 				{data.user_profile_uri ? (
 					<FastImage source={{uri: data.user_profile_uri}} style={styles.img_round_72} />
@@ -64,7 +64,7 @@ const ShelterSmallLabel = props => {
 					<></>
 				)}
 			</View>
-		</View>
+		</TouchableOpacity>
 	);
 };
 

--- a/src/component/organism/article/ArticleSummary.js
+++ b/src/component/organism/article/ArticleSummary.js
@@ -6,7 +6,9 @@ import {APRI10, BLACK, GRAY10, GRAY20, GRAY40, WHITE} from 'Root/config/color';
 import {Photo44} from 'Root/component/atom/icon';
 import {getTimeLapsed} from 'Root/util/dateutil';
 import moment from 'moment';
-import Loading from 'Root/component/molecules/modal/Loading';
+import {useNavigation} from '@react-navigation/core';
+import community_obj from 'Root/config/community_obj';
+
 /**
  * 게시글 컨텐츠
  * @param {object} props - Props Object
@@ -16,8 +18,20 @@ import Loading from 'Root/component/molecules/modal/Loading';
  * @param {boolean} props.selectMode - 검색어
  */
 const ArticleSummary = props => {
-	const data = props.data;
+	const navigation = useNavigation();
+	const [data, setData] = React.useState(props.data);
 	const [text, setText] = React.useState('');
+
+	React.useEffect(() => {
+		const unsubscribe = navigation.addListener('focus', () => {
+			const find = community_obj.editedList.findIndex(e => e._id == props.data._id);
+			if (find != -1) {
+				setData(community_obj.editedList[find]);
+			}
+		});
+		return unsubscribe;
+	}, []);
+
 	const getArticleType = () => {
 		switch (data.community_free_type) {
 			case 'talk':

--- a/src/component/organism/list/ArticleList.js
+++ b/src/component/organism/list/ArticleList.js
@@ -1,11 +1,9 @@
 import React from 'react';
-import {FlatList, StyleSheet, View, Text, NativeModules} from 'react-native';
+import {FlatList, StyleSheet, View} from 'react-native';
 import {GRAY30, GRAY40, WHITE} from 'Root/config/color';
 import DP from 'Root/config/dp';
 import ArticleSummary from '../article/ArticleSummary';
 import {Check42, Check50, Rect42_Border, Rect50_Border} from 'Root/component/atom/icon';
-import {getLinesOfString} from 'Root/util/stringutil';
-import {txt} from 'Root/config/textstyle';
 
 /**
  * 자유 게시글 리스트

--- a/src/component/templete/community/ArticleDetail.js
+++ b/src/component/templete/community/ArticleDetail.js
@@ -167,6 +167,11 @@ export default ArticleDetail = props => {
 					}
 					res.push(dummyForBox);
 					setComments(res);
+					if (props.route.params.comment) {
+						setTimeout(() => {
+							scrollTo(0, -100);
+						}, 1000);
+					}
 				},
 				err => {
 					console.log('getCommentListByCommunityId', err);

--- a/src/component/templete/community/CommunityList.js
+++ b/src/component/templete/community/CommunityList.js
@@ -8,7 +8,7 @@ import ArticleList from 'Root/component/organism/list/ArticleList';
 import {useNavigation} from '@react-navigation/core';
 import Modal from 'Root/component/modal/Modal';
 import userGlobalObject from 'Root/config/userGlobalObject';
-import {getCommunityListByUserId, updateAndDeleteCommunity} from 'Root/api/community';
+import {getCommunityListByUserId} from 'Root/api/community';
 import community_obj, {updateReview} from 'Root/config/community_obj';
 import {setFavoriteEtc} from 'Root/api/favoriteetc';
 import {EmptyIcon} from 'Root/component/atom/icon';
@@ -113,7 +113,7 @@ const CommunityList = React.memo(props => {
 	};
 
 	const getReviewList = isRefresh => {
-		console.log('isRefresh', isRefresh, reviewOffset);
+		// console.log('isRefresh', isRefresh, reviewOffset);
 		setLoading(true);
 		getCommunityListByUserId(
 			{
@@ -150,7 +150,8 @@ const CommunityList = React.memo(props => {
 
 	//리스트 페이징 작업
 	const onEndReached = commtype => {
-		if (commtype == 'free') {
+		console.log('onEndReached type', type);
+		if (type == 'free') {
 			console.log('EndReached Free', free.length % FREE_LIMIT);
 			//페이지당 출력 개수인 LIMIT로 나눴을 때 나머지 값이 0이 아니라면 마지막 페이지 => api 접속 불필요
 			//리뷰 메인 페이지에서는 필터가 적용이 되었을 때도 api 접속 불필요
@@ -229,14 +230,10 @@ const CommunityList = React.memo(props => {
 		return (
 			<View style={{paddingVertical: 130 * DP, alignItems: 'center'}}>
 				<EmptyIcon />
-				<Text style={[txt.noto28]}>목록이 없습니다..</Text>
+				<Text style={[txt.noto28b]}>목록이 없습니다..</Text>
 			</View>
 		);
 	};
-
-	React.useEffect(() => {
-		console.log('type', type);
-	}, [type]);
 
 	const header = () => {
 		return (
@@ -273,10 +270,7 @@ const CommunityList = React.memo(props => {
 										items={free}
 										onPressArticle={onPressArticle} //게시글 내용 클릭
 										whenEmpty={whenEmpty}
-										onEndReached={() => {
-											console.log('type at ArticleList : ', type);
-											type == 'free' ? onEndReached('free') : false;
-										}}
+										onEndReached={onEndReached}
 									/>
 								</View>
 							);
@@ -299,10 +293,7 @@ const CommunityList = React.memo(props => {
 										onPressLike={i => onPressLike(i, true)}
 										onPressUnlike={i => onPressLike(i, false)}
 										showRecommend={false}
-										onEndReached={() => {
-											console.log('type at REviewList', type);
-											type == 'free' ? false : onEndReached('review');
-										}}
+										onEndReached={onEndReached}
 									/>
 								</View>
 							);

--- a/src/component/templete/favorite/FavoriteProtectRequest.js
+++ b/src/component/templete/favorite/FavoriteProtectRequest.js
@@ -1,16 +1,14 @@
 import {useNavigation} from '@react-navigation/core';
 import React from 'react';
 import {FlatList, StyleSheet, View} from 'react-native';
-import {login_style, selectstat_view_style, temp_style} from 'Templete/style_templete';
 import Loading from 'Root/component/molecules/modal/Loading';
 import {getFavoriteEtcListByUserId, setFavoriteEtc, setFavoriteEtcCancelList} from 'Root/api/favoriteetc';
 import userGlobalObject from 'Root/config/userGlobalObject';
-import AnimalNeedHelpList from 'Root/component/organism/list/AnimalNeedHelpList';
 import DP from 'Root/config/dp';
 import ListEmptyInfo from 'Root/component/molecules/info/ListEmptyInfo';
 import SelectStat from 'Root/component/organism/list/SelectStat';
 import ProtectRequest from 'Root/component/organism/listitem/ProtectRequest';
-import {Check42, Check50, Rect42_Border, Rect50_Border} from 'Root/component/atom/icon';
+import {Check42, Rect42_Border, Rect50_Border} from 'Root/component/atom/icon';
 import {updateProtect} from 'Root/config/protect_obj';
 
 export default FavoriteProtectRequest = ({route}) => {
@@ -37,7 +35,7 @@ export default FavoriteProtectRequest = ({route}) => {
 				// console.log('result / getFavoriteEtcListByUserId / FavoriteProtectRequest : ', result.msg[0]);
 				let temp = [];
 				result.msg.map((v, i) => {
-					if (v) {
+					if (v && v.favorite_etc_target_object_id) {
 						v.favorite_etc_target_object_id.is_favorite = v.is_favorite;
 						temp.push(v.favorite_etc_target_object_id);
 					}

--- a/src/component/templete/missing/MissingAnimalDetail.js
+++ b/src/component/templete/missing/MissingAnimalDetail.js
@@ -29,6 +29,7 @@ export default MissingAnimalDetail = props => {
 	const [pressed, setPressed] = React.useState(false);
 	const viewShotRef = useRef();
 	const flatlist = useRef();
+	let mounted = true;
 
 	//페이지 진입 시 실종게시글 상세 데이터 및 댓글 목록 api 접속
 	React.useEffect(() => {
@@ -37,7 +38,10 @@ export default MissingAnimalDetail = props => {
 			getCommnetList();
 			setPressed(false);
 		});
-		return unsubscribe;
+		return () => {
+			unsubscribe();
+			mounted = false;
+		};
 	}, []);
 
 	//게시글 상세데이터 api
@@ -52,25 +56,26 @@ export default MissingAnimalDetail = props => {
 				result.feed_writer_id.is_favorite = result.is_favorite;
 				setData(result);
 				// console.log('data', data.msg);
-				navigation.setParams({writer: data.msg.feed_writer_id._id, isMissingOrReport: true, feed_object: data.msg});
-				// console.log('result', result);
-				const getGender = () => {
-					switch (result.missing_animal_sex) {
-						case 'male':
-							return '남아';
-						case 'female':
-							return '여아';
-						case 'unknown':
-							return '';
-						default:
-							break;
-					}
-				};
-				navigation.setOptions({
-					title: `${result.missing_animal_species}/${result.missing_animal_species_detail}${getGender() ? '/' + getGender() : ''}`,
-				});
+				if (mounted) {
+					navigation.setParams({writer: data.msg.feed_writer_id._id, isMissingOrReport: true, feed_object: data.msg});
+					const getGender = () => {
+						switch (result.missing_animal_sex) {
+							case 'male':
+								return '남아';
+							case 'female':
+								return '여아';
+							case 'unknown':
+								return '';
+							default:
+								break;
+						}
+					};
+					navigation.setOptions({
+						title: `${result.missing_animal_species}/${result.missing_animal_species_detail}${getGender() ? '/' + getGender() : ''}`,
+					});
 
-				fetchMissingPostList(result._id);
+					fetchMissingPostList(result._id);
+				}
 			},
 			err => {
 				console.log('getFeedDetailById / Error / MissingAnimalDetail : ', err);

--- a/src/component/templete/profile/Profile.js
+++ b/src/component/templete/profile/Profile.js
@@ -20,6 +20,7 @@ import ProtectRequest from 'Root/component/organism/listitem/ProtectRequest';
 import {setFavoriteEtc} from 'Root/api/favoriteetc';
 import protect_obj, {updateProtect} from 'Root/config/protect_obj';
 import {styles} from 'Root/component/atom/image/imageStyle';
+import feed_obj from 'Root/config/feed_obj';
 
 export default Profile = ({route}) => {
 	const navigation = useNavigation();
@@ -43,6 +44,13 @@ export default Profile = ({route}) => {
 			fetchData();
 			setFocused(true);
 			setPressed(false);
+			if (feed_obj.shouldUpdateUserProfile) {
+				if (data._id == feed_obj.feed_writer) {
+					getFeedList(0, true, true);
+					feed_obj.shouldUpdateUserProfile = false;
+					feed_obj.feed_writer = '';
+				}
+			}
 		});
 		if (data.user_type == 'shelter') {
 			fetchProtectRequest();
@@ -224,7 +232,7 @@ export default Profile = ({route}) => {
 					getFeedList(i, false, true);
 				}
 			}
-		} else if (protectList.length < requestTotal) {
+		} else if (protectList.length < requestTotal && data.user_type == 'shelter') {
 			//보호소프로필인 경우 보호동물탭
 			console.log('EndReached', protectList.length, 'requestTotal', requestTotal);
 			fetchProtectRequest();
@@ -271,9 +279,13 @@ export default Profile = ({route}) => {
 				navigation.navigate('LoginRequired');
 			});
 		} else if (userGlobalObject.userInfo.user_type == 'user') {
-			Modal.popAvatarSelectFromWriteModal(obj => {
-				userGlobalObject.userInfo && navigation.navigate('FeedWrite', {feedType: 'Feed', feed_avatar_id: obj});
-			});
+			Modal.popAvatarSelectFromWriteModal(
+				obj => {
+					userGlobalObject.userInfo && navigation.navigate('FeedWrite', {feedType: 'Feed', feed_avatar_id: obj});
+				},
+				Modal.close,
+				'profile',
+			);
 		} else {
 			userGlobalObject.userInfo && navigation.navigate('FeedWrite', {feedType: 'Feed'});
 		}

--- a/src/component/templete/profile/Profile.js
+++ b/src/component/templete/profile/Profile.js
@@ -29,6 +29,7 @@ export default Profile = ({route}) => {
 	const [feedTotal, setFeedTotal] = React.useState();
 	const [tagFeedTotal, setTagFeedTotal] = React.useState();
 	const [protectList, setProtectList] = React.useState('false');
+	const [requestTotal, setRequestTotal] = React.useState(0);
 	const [offset, setOffset] = React.useState(1); //커뮤니티 페이지
 	const [loading, setLoading] = React.useState(false);
 	const [pressed, setPressed] = React.useState(false);
@@ -107,6 +108,7 @@ export default Profile = ({route}) => {
 			result => {
 				// console.log('result / getProtectRequestListByShelterId / AnimalFromShelter', result.msg.length);
 				const res = result.msg;
+				setRequestTotal(result.total_count);
 				console.log('getProtectRequestListByShelterId / res.length', res.length);
 				if (protectList != 'false') {
 					console.log('temp lenth', [...protectList, ...res].length);
@@ -222,9 +224,9 @@ export default Profile = ({route}) => {
 					getFeedList(i, false, true);
 				}
 			}
-		} else if (protectList.length % PROTECT_REQUEST_DETAIL_LIMIT == 0) {
+		} else if (protectList.length < requestTotal) {
 			//보호소프로필인 경우 보호동물탭
-			console.log('EndReached', protectList.length % PROTECT_REQUEST_DETAIL_LIMIT);
+			console.log('EndReached', protectList.length, 'requestTotal', requestTotal);
 			fetchProtectRequest();
 		}
 	};
@@ -499,7 +501,8 @@ export default Profile = ({route}) => {
 						/>
 					);
 				}
-			} else {
+			} else if (data.user_type == 'shelter') {
+				//보호소 계정
 				if (tabMenuSelected == 0) {
 					return (
 						<FeedThumbnailList

--- a/src/component/templete/protection/AnimalProtectRequestDetail.js
+++ b/src/component/templete/protection/AnimalProtectRequestDetail.js
@@ -28,7 +28,8 @@ import {Phone54, PhoneIcon, ProfileDefaultImg} from 'Root/component/atom/icon';
 export default AnimalProtectRequestDetail = ({route}) => {
 	const navigation = useNavigation();
 	const [data, setData] = React.useState('false');
-	const [writersAnotherRequests, setWritersAnotherRequests] = React.useState('false'); //해당 게시글 작성자의 따른 보호요청게시글 목록
+	const [writersAnotherRequests, setWritersAnotherRequests] = React.useState('false'); //해당 게시글 작성자의 다른 보호요청게시글 목록(현재 글 제외)
+	const [total, setTotal] = React.useState(0); //해당 게시글 작성자의 보호요청게시글 작성글 총 개수
 	const [comments, setComments] = React.useState('false'); //comment list 정보
 	const [offset, setOffset] = React.useState(1);
 	const [pressed, setPressed] = React.useState(false);
@@ -93,11 +94,13 @@ export default AnimalProtectRequestDetail = ({route}) => {
 			{
 				shelter_userobject_id: request.protect_request_writer_id._id,
 				protect_request_status: 'all', //하단 리스트
-				limit: 5,
+				limit: PROTECT_REQUEST_DETAIL_LIMIT,
 				page: offset,
 			},
 			result => {
-				console.log('result / getProtectRequestListByShelterId / AnimalProtectRequestDetail : ', result.msg.length);
+				// console.log('result / getProtectRequestListByShelterId / AnimalProtectRequestDetail : ', result.msg.length);
+				// console.log('tota', result.total_count);
+				setTotal(result.total_count);
 				//현재 보고 있는 보호요청게시글의 작성자(보호소)의 모든 보호요청게시글이 담겨 있는 writersAnotherRequests
 				//그러나 현재 보고 있는 보호요청게시글은 해당 리스트에 출력이 되어서는 안됨 => Filter처리
 				const res = result.msg;
@@ -128,10 +131,10 @@ export default AnimalProtectRequestDetail = ({route}) => {
 
 	//리스트 페이징 작업
 	const onEndReached = () => {
-		console.log('EndReached', writersAnotherRequests.length % (PROTECT_REQUEST_DETAIL_LIMIT - 1));
+		console.log('EndReached', writersAnotherRequests.length, 'total : ', total);
 		//페이지당 출력 개수인 LIMIT로 나눴을 때 나머지 값이 0이 아니라면 마지막 페이지 => api 접속 불필요
 		//리뷰 메인 페이지에서는 필터가 적용이 되었을 때도 api 접속 불필요
-		if (writersAnotherRequests.length % PROTECT_REQUEST_DETAIL_LIMIT == 0) {
+		if (writersAnotherRequests.length < total) {
 			getProtectRequestList(data);
 		}
 	};

--- a/src/config/community_obj.js
+++ b/src/config/community_obj.js
@@ -14,6 +14,16 @@ export default community_obj = {
 		},
 	},
 	review: [],
+	editedList: [],
+};
+
+export const pushEditedCommunityList = res => {
+	const findIndex = community_obj.editedList.findIndex(e => e._id == res._id);
+	if (findIndex != -1) {
+		community_obj.editedList[findIndex] = res;
+	} else {
+		community_obj.editedList.push(res);
+	}
 };
 
 export const updateReview = (isLike, id, bool, count) => {

--- a/src/config/feed_obj.js
+++ b/src/config/feed_obj.js
@@ -6,5 +6,6 @@ export default feed_obj = {
 	deleted_obj: {},
 	deleted_list: [],
 	mainHomeFeedList: [],
-	isGpsDenied: false,
+	shouldUpdateUserProfile: false,
+	feed_writer: '',
 };

--- a/src/i18n/msg.js
+++ b/src/i18n/msg.js
@@ -584,4 +584,4 @@ export const THUMNAIL_LIMIT = 30; //썸네일리스트
 export const FEED_LIMIT = 10; //피드 메인
 export const ANIMAL_PROTECT_LIMIT = 10; //Usermenu => 동물보호 현황(임시보호 중인 동물 현황)
 export const ANIMAL_ADOPT_LIMIT = 20; //UserMenu => 신청 내역 => 입양 신청 더보기 클릭
-export const PROTECT_REQUEST_DETAIL_LIMIT = 10; //보호요청게시글 상세 하단 리스트
+export const PROTECT_REQUEST_DETAIL_LIMIT = 20; //보호요청게시글 상세 하단 리스트

--- a/src/navigation/header/FeedWriteHeader.js
+++ b/src/navigation/header/FeedWriteHeader.js
@@ -258,41 +258,6 @@ export default FeedWriteHeader = ({route, options}) => {
 				};
 
 				console.log('onEdit / FeedWrtieHeader', param);
-				const te = {
-					__v: 0,
-					_id: '62d60cae9b725bf32986f8e3',
-					feed_comment_count: 0,
-					feed_content: '피드 수정 태그 추가',
-					feed_date: '2022-07-19T01:45:18.764Z',
-					feed_favorite_count: 0,
-					feed_is_delete: false,
-					feed_is_like: false,
-					feed_is_protect_diary: false,
-					feed_like_count: 0,
-					feed_medias: [
-						{
-							duration: 0,
-							is_video: false,
-							media_uri: 'https://pinetreegy.s3.ap-northeast-2.amazonaws.com/upload/1658195118657_4CB89490-1641-4DF8-92BB-CC9E8AFEA2E8.jpg',
-							tags: [Array],
-						},
-					],
-					feed_public_type: 'public',
-					feed_thumbnail: 'https://pinetreegy.s3.ap-northeast-2.amazonaws.com/upload/1658195118657_4CB89490-1641-4DF8-92BB-CC9E8AFEA2E8.jpg',
-					feed_type: 'feed',
-					feed_update_date: '2022-07-19T01:45:18.764Z',
-					feedobject_id: '62d60cae9b725bf32986f8e3',
-					hashtag_keyword: [],
-					height: 505.44,
-					is_favorite: false,
-					media_uri: undefined,
-					missing_animal_date: '2022-07-19T01:45:18.764Z',
-					offset: 143.52,
-					photoToDelete: [],
-					report_witness_date: '2022-07-19T01:45:18.764Z',
-					routeName: undefined,
-					type: 'FeedObject',
-				};
 				if (param.feed_type == 'feed') {
 					if (param.feed_medias[0].is_video) {
 						createThumbnail({url: param.feed_medias[0].media_uri, timeStamp: 500})

--- a/src/navigation/header/SendHeader.js
+++ b/src/navigation/header/SendHeader.js
@@ -8,6 +8,8 @@ import Modal from 'Root/component/modal/Modal';
 import {createProtectRequest, updateProtectRequest} from 'Root/api/shelterapi';
 import {RED} from 'Root/config/color';
 import {createCommunity, updateAndDeleteCommunity} from 'Root/api/community';
+import community_obj, {pushEditedCommunityList} from 'Root/config/community_obj';
+import comment_obj from 'Root/config/comment_obj';
 
 export default SendHeader = ({route, navigation, options}) => {
 	// console.log('props SendHeader', route.params);
@@ -19,7 +21,6 @@ export default SendHeader = ({route, navigation, options}) => {
 			if (route.params.data) {
 				const data = route.params.data;
 				// console.log('data at SendHeader', JSON.stringify(data));
-				console.log('route.params.nav', route.params.nav);
 				switch (route.params.nav) {
 					case 'CommunityWrite': {
 						if (!data.community_content || !data.community_title) {
@@ -78,42 +79,10 @@ export default SendHeader = ({route, navigation, options}) => {
 											community_is_attached_file: attachedCheck,
 										},
 										result => {
-											// console.log('result / updateAndDeleteCommunity / SendHeader ', result.msg);
-											console.log('param', route.params.isSearch);
-											if (route.params.isSearch) {
-												result.msg.community_type == 'review'
-													? navigation.reset({
-															index: 1,
-															routes: [
-																{name: 'SearchTab', params: {tab: 'REVIEW'}},
-																{name: 'ReviewDetail', params: {community_object: result.msg, searchInput: route.params.isSearch}},
-															],
-													  })
-													: navigation.reset({
-															index: 1,
-															routes: [
-																{name: 'SearchTab', params: {tab: 'ARTICLE'}},
-																{name: 'ArticleDetail', params: {community_object: result.msg, searchInput: route.params.isSearch}},
-															],
-													  });
-											} else {
-												// console.log('navi', navigation.getState());
-												result.msg.community_type == 'review'
-													? navigation.reset({
-															index: 1,
-															routes: [
-																{name: 'CommunityMain', params: {isReview: true}},
-																{name: 'ReviewDetail', params: {community_object: result.msg}},
-															],
-													  })
-													: navigation.reset({
-															index: 1,
-															routes: [
-																{name: 'CommunityMain', params: {isReview: false}},
-																{name: 'ArticleDetail', params: {community_object: result.msg}},
-															],
-													  });
-											}
+											console.log('result / updateAndDeleteCommunity / SendHeader ', result.msg.community_is_attached_file);
+											const res = result.msg;
+											pushEditedCommunityList(res);
+											navigation.goBack();
 										},
 										err => {
 											console.log('err / updateAndDeleteCommunity / sendHeader ', err);

--- a/src/navigation/route/main_tab/protection_stack/ProtectionStackNavigation.js
+++ b/src/navigation/route/main_tab/protection_stack/ProtectionStackNavigation.js
@@ -35,6 +35,10 @@ import CommunityEdit from 'Root/component/templete/community/CommunityEdit';
 import SendHeader from 'Root/navigation/header/SendHeader';
 import FeedWrite from 'Root/component/templete/feed/FeedWrite';
 import FeedWriteHeader from 'Root/navigation/header/FeedWriteHeader';
+import LocationPicker from 'Root/component/templete/search/LocationPicker';
+import ConfirmHeader from 'Root/navigation/header/ConfirmHeader';
+import FeedMediaTagEdit from 'Root/component/templete/feed/FeedMediaTagEdit';
+import AccountPicker from 'Root/component/templete/search/AccountPicker';
 
 const ProtectionStack = createStackNavigator();
 
@@ -185,6 +189,19 @@ export default ProtectionStackNavigation = props => {
 				component={FeedWrite}
 				options={{header: props => <FeedWriteHeader {...props} />, title: '제보 게시물'}}
 			/>
+			<ProtectionStack.Screen
+				name="FeedLocationPicker"
+				component={LocationPicker}
+				options={{header: props => <InputAndSearchHeader {...props} type={'location'} />}}
+			/>
+			<ProtectionStack.Screen
+				name="FeedMediaTagEdit"
+				component={FeedMediaTagEdit}
+				options={{header: props => <ConfirmHeader {...props} />, title: ''}}
+			/>
+			<ProtectionStack.Screen name="UserList" options={{header: props => <InputAndSearchHeader {...props} />, title: '계정'}}>
+				{props => <AccountPicker {...props} /*prevNav={props.prevNav} input={searchInput} onClickUser={onClickUser}*/ />}
+			</ProtectionStack.Screen>
 		</ProtectionStack.Navigator>
 	);
 };


### PR DESCRIPTION
*수정 사항:
*수정 결과:
*수정 파일: 
1) src/component/organism/feed/FeedContent.js
- 메시지 전송 실패 분기 추가
- 피드의 미트볼 클릭 시 즐겨찾기 판별하는 api 접속이 불필요해짐에 따라 제거

2) src/component/templete/community/ArticleDetail.js
- 알람리스트에서 자신이 작성한 자유게시글에 댓글이 달렸다는 알림을 선택했을 경우 댓글 영역으로 자동 스크롤 되도록 적용

3) src/component/templete/favorite/FavoriteProtectRequest.js
- 즐겨찾기한 보호요청 게시글이 삭제된 게시글이었을 경우 참조를 하지 않도록 수정

4) src/component/templete/list/AlarmList.js
- 알림 아이템 선택 시 로딩 절차 적용

5) src/component/templete/profile/Profile.js
     src/component/templete/protection/AnimalProtectRequestDetail.js
- 특정 보호소의 보호요청게시글 받아오는 api의 total_count 적용 

6) src/component/templete/search/LocationPicker.js
- 안드로이드 10 버전에서 위치 권한 request가 반복적으로 출력되는 오류 수정 중 (미완료)

7) src/component/organism/article/ArticleSummary.js
     src/config/community_obj.js
- 자유 게시글 수정 발생시, 이미지 첨부 여부, 타이틀, 게시글 타입 등이 리스트 게시글에서 갱신되도록 수정

8) src/component/templete/community/CommunityList.js
- 프로필 홈 => 커뮤니티 탭에서 자유글, 리뷰의 onEndReached 페이징이 동시에 발생하던 현상 수정

9) src/component/templete/missing/MissingAnimalDetail.js
- 실종 상세글 페이지가 unMounted됐을 경우 setParams를 수행하지 않도록 수정

10) src/component/templete/profile/Profile.js
      src/config/feed_obj.js
- 프로필화면에서 피드 글쓰기 => 글쓰기 완료 후 나의 프로필 홈으로 돌아왔을 때 나의 피드 게시글 목록이 갱신되도록 수정

11) src/navigation/header/FeedWriteHeader.js
- 동물보호 탭에서 프로필 홈 혹은 피드리스트 페이지 진입 => 피드 글쓰기 => 피드 글쓰기 완료 후 메인탭으로 이동되지 않고 이전 페이지로 이동 되도록 수정 

12) src/navigation/header/SendHeader.js
- 커뮤니티 게시글 수정 후 피드 탭, 동물보호, MY탭에서 네비게이션 이동이 되지 않던 현상 수정

