### PR TITLE
[상우] UI 오류 사항 수정 / 알람 페이지 코드 개선

### DIFF
--- a/src/component/molecules/input/Input24.js
+++ b/src/component/molecules/input/Input24.js
@@ -175,8 +175,9 @@ const Input24 = React.forwardRef((props, ref) => {
 						props.style || {color: MAINBLACK},
 						{
 							width: props.width ? (props.width - 46) * DP : null,
-							paddingLeft: 24 * DP,
-							height: '100%', //ios에서 안드로이드와 동작 일치시키기 위함
+							// paddingLeft: 24 * DP,
+							paddingHorizontal: 24 * DP,
+							height: props.heightRatio, //ios에서 안드로이드와 동작 일치시키기 위함
 							// height: props.height,
 							lineHeight: 44 * DP,
 							fontSize: props.value ? 28 * DP : props.placeholderSize * DP,
@@ -232,6 +233,8 @@ const Input24Props = {
 	/** @type {number} 최대 글자수 */
 	maxlength: number,
 	/** @type {number} Placeholder 폰트사이즈 */
+	heightRatio: any,
+	/** @type {number} 높이 비율 */
 	placeholderSize: number,
 	/** @type {boolean} 하단의 경고/확인 메세지를 표시할지 여부를 결정 */
 	showMsg: bool,
@@ -277,6 +280,7 @@ Input24.defaultProps = {
 	info: null, //
 	numberOfLines: 1,
 	placeholderSize: 28,
+	heightRatio: '100%',
 	multiline: false,
 	defaultValue: null, // 기존 아이디 등 DefaultValue가 필요한 경우에 대한 처리
 	showCrossMark: true, //Input 최우측 X마크(지우기마크) 출력 여부

--- a/src/component/molecules/modal/InformationModal.js
+++ b/src/component/molecules/modal/InformationModal.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import moment from 'moment';
-import {View, Text, TouchableOpacity, StyleSheet, Platform, Dimensions, TouchableWithoutFeedback, FlatList, Linking} from 'react-native';
+import {View, Text, TouchableOpacity, StyleSheet, Platform, Dimensions, Linking} from 'react-native';
 import {WHITE, GRAY10, APRI10, GRAY20, APRI20, GRAY30, BLACK, BLUE20} from 'Root/config/color';
 import {txt} from 'Root/config/textstyle';
 import DP from 'Root/config/dp';
-import {Arrow_Down_GRAY10, Arrow_Up_GRAY20, Cross24, Cross24_Filled, Cross24_White, Female48, Male48} from 'Atom/icon';
+import {Cross24_Filled, Female48, Male48} from 'Atom/icon';
 import AniButton from 'Molecules/button/AniButton';
 import {btn_w130, btn_w136, btn_w226} from 'Atom/btn/btn_style';
 import userGlobalObject from 'Root/config/userGlobalObject';
@@ -21,7 +21,6 @@ import Modal from 'Root/component/modal/Modal';
  */
 const InformationModal = props => {
 	const data = props.data;
-	console.log('datatata', data);
 	const userInfo = userGlobalObject.userInfo;
 	const isOwner = () => {
 		let result = false;
@@ -67,263 +66,188 @@ const InformationModal = props => {
 	};
 
 	const getContents = () => {
-		if (data.user_type == 'pet') {
-			let user_interest_list = [];
-			user_interest_list = user_interest_list.concat(data.pet_family[0].user_interests.interests_activity);
-			user_interest_list = user_interest_list.concat(data.pet_family[0].user_interests.interests_beauty);
-			user_interest_list = user_interest_list.concat(data.pet_family[0].user_interests.interests_food);
-			user_interest_list = user_interest_list.concat(data.pet_family[0].user_interests.interests_health);
-			user_interest_list = user_interest_list.filter(e => e != undefined);
-			user_interest_list = new Set(user_interest_list);
-			user_interest_list = [...user_interest_list];
-			console.log('user_interest_list', user_interest_list);
-			return (
-				<>
-					{/* 중성화 */}
-					{/* <View style={[style.category]}>
-							<View style={[style.category_title]}>
-								<Text style={[txt.noto24]}>중성화</Text>
-							</View>
-							<View style={[style.category_content]}>
-								<Text style={[txt.noto30, {color: GRAY10}]}>{getNeutralization()}</Text>
-							</View>
-						</View> */}
-					{/* </View> */}
-					<View style={[style.info_step2]}>
-						{/* 관심사 */}
-						<View style={[style.category_step2]}>
-							<View style={{width: 604 * DP, height: 54 * DP, alignItems: 'center'}}>
-								<Text style={[txt.noto36b]}>
-									{data.pet_species} / {data.pet_species_detail}
-								</Text>
-							</View>
-							<View style={[style.category]}>
-								<View style={[style.category_title, {marginTop: 30 * DP}]}>
-									<Text style={[txt.noto26, {color: GRAY10}]}>성별</Text>
-								</View>
-								<View style={[style.category_content]}>{data.pet_sex == 'male' ? <Male48 /> : <Female48 />}</View>
-							</View>
-							<View style={[style.category, {marginTop: 50 * DP}]}>
-								<View style={[style.category_title]}>
-									<Text style={[txt.noto26, {color: GRAY10}]}>생일</Text>
-								</View>
-								<View style={[style.category_content]}>
-									<Text style={[txt.roboto28, {}]}>{getBirthDate()}</Text>
-								</View>
-							</View>
-							{/* <View style={[style.category_title]}>
-								<Text style={[txt.noto24]}>관심사</Text>
-							</View> */}
-							{/* <View style={[style.category_step2_content]}>
-								<Text
-									style={[txt.noto30, {color: GRAY10, position: 'absolute', opacity: 0}]}
-									onTextLayout={({nativeEvent: {lines}}) => {
-										setNumberOfLines(lines.length);
-									}}>
-									{user_interest_list.map((v, i) => {
-										return v + (i != user_interest_list.length - 1 ? ', ' : '');
-									})}
-								</Text>
-								<View style={{flexDirection: 'row', width: 502 * DP, marginBottom: 20 * DP}}>
-									<Text style={[txt.noto30, {color: GRAY10}]} numberOfLines={showMore ? numberOfLines : 2}>
-										{user_interest_list.map((v, i) => {
-											return v + (i != user_interest_list.length - 1 ? ', ' : '');
-										})}
+		try {
+			if (data.user_type == 'pet') {
+				return (
+					<>
+						<View style={[style.info_step2]}>
+							{/* 관심사 */}
+							<View style={[style.category_step2]}>
+								<View style={{width: 604 * DP, height: 54 * DP, alignItems: 'center'}}>
+									<Text style={[txt.noto36b]}>
+										{data.pet_species} / {data.pet_species_detail}
 									</Text>
 								</View>
-								{numberOfLines > 2 ? (
-									showMore ? (
-										<TouchableOpacity onPress={() => setShowMore(!showMore)}>
-											<View style={{flexDirection: 'row'}}>
-												<Text style={[txt.noto24, {color: GRAY10}]}>접기</Text>
-												<Arrow_Up_GRAY20 />
+								<View style={[style.category]}>
+									<View style={[style.category_title, {marginTop: 30 * DP}]}>
+										<Text style={[txt.noto26, {color: GRAY10}]}>성별</Text>
+									</View>
+									<View style={[style.category_content]}>{data.pet_sex == 'male' ? <Male48 /> : <Female48 />}</View>
+								</View>
+								<View style={[style.category, {marginTop: 50 * DP}]}>
+									<View style={[style.category_title]}>
+										<Text style={[txt.noto26, {color: GRAY10}]}>생일</Text>
+									</View>
+									<View style={[style.category_content]}>
+										<Text style={[txt.roboto28, {}]}>{getBirthDate()}</Text>
+									</View>
+								</View>
+							</View>
+						</View>
+						{isOwner() ? (
+							<View>
+								<AniButton onPress={onPressEdit} btnLayout={btn_w136} btnStyle={'border'} btnTitle={'수정'} />
+							</View>
+						) : (
+							<></>
+						)}
+					</>
+				);
+			} else if (data.user_type == 'shelter') {
+				//보호소 계정의 정보
+				return (
+					<View style={[{marginTop: 48 * DP}]}>
+						<View style={[style.category, {marginTop: 60 * DP, marginBottom: 0 * DP}]}>
+							<Text style={[txt.noto32b]}>{data.user_nickname}</Text>
+						</View>
+						{/* 주소 */}
+						<View style={[style.shelter_address]}>
+							<View style={[style.category_title]}>
+								<Text style={[txt.noto26, {color: GRAY10}]}>주소</Text>
+							</View>
+							<Text numberOfLines={2} style={[txt.noto28, {textAlign: 'center'}]}>
+								{data.shelter_address.brief}
+							</Text>
+						</View>
+						{/* 전화번호 */}
+						<View style={[style.category]}>
+							<View style={[style.category_title]}>
+								<Text style={[txt.noto26, {color: GRAY10}]}>전화번호</Text>
+							</View>
+							<Text
+								onPress={() => Linking.openURL(`tel:${data.shelter_delegate_contact_number}`)}
+								style={[txt.roboto28, {textDecorationLine: 'underline', color: BLUE20, marginTop: 12 * DP}]}>
+								{data.shelter_delegate_contact_number || ''}
+							</Text>
+						</View>
+						{/* Email */}
+						<View style={[style.category]}>
+							<View style={[style.category_title]}>
+								<Text style={[txt.noto26, {color: GRAY10}]}>Email</Text>
+							</View>
+							<Text style={[txt.roboto28, {marginTop: 12 * DP}]}>{data.user_email || '등록된 이메일이 없습니다.'}</Text>
+						</View>
+						{/* 설립일 */}
+						<View style={[style.category]}>
+							<View style={[style.category_title]}>
+								<Text style={[txt.noto26, {color: GRAY10}]}>설립일</Text>
+							</View>
+							<Text style={[txt.roboto28, {marginTop: 12 * DP}]}>
+								{data.shelter_foundation_date ? moment(data.shelter_foundation_date).format('YYYY/MM/DD') : '미등록 상태입니다.'}{' '}
+							</Text>
+						</View>
+						{data._id == userInfo._id ? (
+							<View style={{alignSelf: 'center', marginVertical: 30 * DP}}>
+								<AniButton onPress={onPressEdit} btnLayout={btn_w226} btnStyle={'border'} btnTitle={'수정'} />
+							</View>
+						) : (
+							<></>
+						)}
+					</View>
+				);
+			} else {
+				//유저 프로필 정보
+				try {
+					if (data.user_interests) {
+						let user_interest_list = [];
+
+						if (
+							(data.user_interests.hasOwnProperty('interests_group1') || data.user_interests.hasOwnProperty('interests_group2'),
+							data.user_interests.hasOwnProperty('interests_group3'))
+						) {
+							user_interest_list = user_interest_list.concat(data.user_interests.interests_group1);
+							user_interest_list = user_interest_list.concat(data.user_interests.interests_group2);
+							user_interest_list = user_interest_list.concat(data.user_interests.interests_group3);
+							user_interest_list = user_interest_list.concat(data.user_interests.interests_etc);
+						} else {
+							user_interest_list = user_interest_list.concat(data.user_interests.interests_activity);
+							user_interest_list = user_interest_list.concat(data.user_interests.interests_beauty);
+							user_interest_list = user_interest_list.concat(data.user_interests.interests_food);
+							user_interest_list = user_interest_list.concat(data.user_interests.interests_health);
+						}
+
+						user_interest_list = user_interest_list.filter(e => e != undefined);
+						user_interest_list = new Set(user_interest_list);
+						user_interest_list = [...user_interest_list];
+						// console.log('user', user_interest_list);
+						user_interest_list = [];
+						return (
+							<>
+								<View style={[style.info_step2]}>
+									{/* <View style={[{marginBottom: 40 * DP, alignSelf: 'center'}]}>
+										<Text style={[txt.noto32b]}>
+											{data.user_nickname || ''}
+											<Text style={[txt.noto28, {color: BLACK}]}> 님의 정보</Text>
+										</Text>
+									</View> */}
+									{/* 관심사 */}
+									<View style={[style.category_step2, {paddingBottom: 20 * DP}]}>
+										<View style={[style.category_title]}>
+											<Text style={[txt.noto26, {color: GRAY10}]}>관심사</Text>
+										</View>
+										<View style={[style.category_step2_content]}>
+											{/* 더미 텍스트컴포넌트 - 조정되기 이전의 numberOfLine 판별용 */}
+											<Text
+												style={[txt.noto28, {position: 'absolute', opacity: 0}]}
+												onTextLayout={({nativeEvent: {lines}}) => {
+													setNumberOfLines(lines.length);
+												}}>
+												{user_interest_list.map((v, i) => {
+													return v + (i != user_interest_list.length - 1 ? ', ' : '');
+												})}
+											</Text>
+											{/* 더미 텍스트 컴포넌트 종료 */}
+											<View style={{flexDirection: 'row', width: 620 * DP, marginBottom: 20 * DP, marginTop: 10 * DP, justifyContent: 'center'}}>
+												{user_interest_list && user_interest_list.length == 0 ? (
+													<Text
+														style={[
+															txt.noto28,
+															{
+																// width: 620 * DP,
+																marginTop: 10 * DP,
+																textAlign: 'center',
+															},
+														]}>
+														아직 {data.user_nickname}님의 관심사 설정이 되지 않았습니다.
+													</Text>
+												) : (
+													<Text style={[txt.noto28]} numberOfLines={showMore ? numberOfLines : null}>
+														{user_interest_list.map((v, i) => {
+															return v + (i != user_interest_list.length - 1 ? ', ' : '');
+														})}
+													</Text>
+												)}
 											</View>
-										</TouchableOpacity>
-									) : (
-										<TouchableOpacity onPress={() => setShowMore(!showMore)}>
-											<View style={{flexDirection: 'row'}}>
-												<Text style={[txt.noto24, {color: GRAY10}]}>펼치기</Text>
-												<Arrow_Down_GRAY10 />
-											</View>
-										</TouchableOpacity>
-									)
+										</View>
+									</View>
+								</View>
+								{data._id == userInfo._id ? (
+									<View>
+										<AniButton onPress={onPressEdit} btnLayout={btn_w136} btnStyle={'border'} btnTitle={'수정'} />
+									</View>
 								) : (
 									<></>
 								)}
-							</View> */}
-						</View>
-					</View>
-					{isOwner() ? (
-						<View>
-							<AniButton onPress={onPressEdit} btnLayout={btn_w136} btnStyle={'border'} btnTitle={'수정'} />
-						</View>
-					) : (
-						<></>
-					)}
-				</>
-			);
-		} else if (data.user_type == 'shelter') {
-			//보호소 계정의 정보
-			return (
-				<View style={[{marginTop: 48 * DP}]}>
-					<View style={[style.category, {marginTop: 60 * DP, marginBottom: 0 * DP}]}>
-						<Text style={[txt.noto32b]}>{data.user_nickname}</Text>
-					</View>
-					{/* 주소 */}
-					<View style={[style.shelter_address]}>
-						<View style={[style.category_title]}>
-							<Text style={[txt.noto26, {color: GRAY10}]}>주소</Text>
-						</View>
-						<Text numberOfLines={2} style={[txt.noto28, {textAlign: 'center'}]}>
-							{data.shelter_address.brief}
-						</Text>
-					</View>
-					{/* 전화번호 */}
-					<View style={[style.category]}>
-						<View style={[style.category_title]}>
-							<Text style={[txt.noto26, {color: GRAY10}]}>전화번호</Text>
-						</View>
-						<Text
-							onPress={() => Linking.openURL(`tel:${data.shelter_delegate_contact_number}`)}
-							style={[txt.roboto28, {textDecorationLine: 'underline', color: BLUE20, marginTop: 12 * DP}]}>
-							{data.shelter_delegate_contact_number || ''}
-						</Text>
-					</View>
-					{/* Email */}
-					<View style={[style.category]}>
-						<View style={[style.category_title]}>
-							<Text style={[txt.noto26, {color: GRAY10}]}>Email</Text>
-						</View>
-						<Text style={[txt.roboto28, {marginTop: 12 * DP}]}>{data.user_email || '등록된 이메일이 없습니다.'}</Text>
-					</View>
-					{/* 설립일 */}
-					<View style={[style.category]}>
-						<View style={[style.category_title]}>
-							<Text style={[txt.noto26, {color: GRAY10}]}>설립일</Text>
-						</View>
-						<Text style={[txt.roboto28, {marginTop: 12 * DP}]}>
-							{data.shelter_foundation_date ? moment(data.shelter_foundation_date).format('YYYY/MM/DD') : '미등록 상태입니다.'}{' '}
-						</Text>
-					</View>
-					{data._id == userInfo._id ? (
-						<View style={{alignSelf: 'center', marginVertical: 30 * DP}}>
-							<AniButton onPress={onPressEdit} btnLayout={btn_w226} btnStyle={'border'} btnTitle={'수정'} />
-						</View>
-					) : (
-						<></>
-					)}
-				</View>
-			);
-		} else {
-			//유저 프로필 정보
-			try {
-				if (data.user_interests) {
-					let user_interest_list = [];
-
-					if (
-						(data.user_interests.hasOwnProperty('interests_group1') || data.user_interests.hasOwnProperty('interests_group2'),
-						data.user_interests.hasOwnProperty('interests_group3'))
-					) {
-						user_interest_list = user_interest_list.concat(data.user_interests.interests_group1);
-						user_interest_list = user_interest_list.concat(data.user_interests.interests_group2);
-						user_interest_list = user_interest_list.concat(data.user_interests.interests_group3);
-						user_interest_list = user_interest_list.concat(data.user_interests.interests_etc);
-					} else {
-						user_interest_list = user_interest_list.concat(data.user_interests.interests_activity);
-						user_interest_list = user_interest_list.concat(data.user_interests.interests_beauty);
-						user_interest_list = user_interest_list.concat(data.user_interests.interests_food);
-						user_interest_list = user_interest_list.concat(data.user_interests.interests_health);
+							</>
+						);
 					}
-
-					user_interest_list = user_interest_list.filter(e => e != undefined);
-					user_interest_list = new Set(user_interest_list);
-					user_interest_list = [...user_interest_list];
-					console.log('user', user_interest_list);
-					user_interest_list = [];
-					return (
-						<>
-							<View style={[style.info_step2]}>
-								{/* <View style={[{marginBottom: 40 * DP, alignSelf: 'center'}]}>
-									<Text style={[txt.noto32b]}>
-										{data.user_nickname || ''}
-										<Text style={[txt.noto28, {color: BLACK}]}> 님의 정보</Text>
-									</Text>
-								</View> */}
-								{/* 관심사 */}
-								<View style={[style.category_step2, {paddingBottom: 20 * DP}]}>
-									<View style={[style.category_title]}>
-										<Text style={[txt.noto26, {color: GRAY10}]}>관심사</Text>
-									</View>
-									<View style={[style.category_step2_content]}>
-										{/* 더미 텍스트컴포넌트 - 조정되기 이전의 numberOfLine 판별용 */}
-										<Text
-											style={[txt.noto28, {position: 'absolute', opacity: 0}]}
-											onTextLayout={({nativeEvent: {lines}}) => {
-												setNumberOfLines(lines.length);
-											}}>
-											{user_interest_list.map((v, i) => {
-												return v + (i != user_interest_list.length - 1 ? ', ' : '');
-											})}
-										</Text>
-										{/* 더미 텍스트 컴포넌트 종료 */}
-										<View style={{flexDirection: 'row', width: 620 * DP, marginBottom: 20 * DP, marginTop: 10 * DP, justifyContent: 'center'}}>
-											{user_interest_list && user_interest_list.length == 0 ? (
-												<Text
-													style={[
-														txt.noto28,
-														{
-															// width: 620 * DP,
-															marginTop: 10 * DP,
-															textAlign: 'center',
-														},
-													]}>
-													아직 {data.user_nickname}님의 관심사 설정이 되지 않았습니다.
-												</Text>
-											) : (
-												<Text style={[txt.noto28]} numberOfLines={showMore ? numberOfLines : null}>
-													{user_interest_list.map((v, i) => {
-														return v + (i != user_interest_list.length - 1 ? ', ' : '');
-													})}
-												</Text>
-											)}
-										</View>
-										{/* {numberOfLines > 2 ? (
-											//관심사 항목이 2줄을 넘은 경우 '펼치기 / 접기' 를 출력
-											showMore ? (
-												<TouchableOpacity onPress={() => setShowMore(!showMore)}>
-													<View style={{flexDirection: 'row'}}>
-														<Text style={[txt.noto24, {color: GRAY10}]}>접기</Text>
-														<Arrow_Up_GRAY20 />
-													</View>
-												</TouchableOpacity>
-											) : (
-												<TouchableOpacity onPress={() => setShowMore(!showMore)}>
-													<View style={{flexDirection: 'row'}}>
-														<Text style={[txt.noto24, {color: GRAY10}]}>펼치기</Text>
-														<Arrow_Down_GRAY10 />
-													</View>
-												</TouchableOpacity>
-											)
-										) : (
-											<></>
-										)} */}
-									</View>
-								</View>
-							</View>
-							{data._id == userInfo._id ? (
-								<View>
-									<AniButton onPress={onPressEdit} btnLayout={btn_w136} btnStyle={'border'} btnTitle={'수정'} />
-								</View>
-							) : (
-								<></>
-							)}
-						</>
-					);
+				} catch (err) {
+					console.log('err InformationModal', err);
+					return <></>;
 				}
-			} catch (err) {
-				console.log('err InformationModal', err);
-				return <></>;
 			}
+		} catch (err) {
+			console.log('err', err);
 		}
 	};
 

--- a/src/component/templete/favorite/FavoriteArticle.js
+++ b/src/component/templete/favorite/FavoriteArticle.js
@@ -33,7 +33,7 @@ export default FavoriteArticle = ({route, isFavorite}) => {
 		!isFavorite
 			? getCommunityListByUserId(
 					{
-						limit: 100,
+						limit: 1000,
 						page: offset,
 						userobject_id: userGlobalObject.userInfo._id,
 						community_type: 'free',

--- a/src/component/templete/favorite/FavoriteReview.js
+++ b/src/component/templete/favorite/FavoriteReview.js
@@ -25,14 +25,23 @@ export default FavoriteReview = ({route, isFavorite}) => {
 	const [offset, setOffset] = React.useState(1);
 
 	React.useEffect(() => {
-		const unsubscribe = navigation.addListener('focus', () => {
-			// fetchData();
-		});
 		fetchData();
-		return unsubscribe;
 	}, []);
 
 	React.useEffect(() => {
+		const unsubscribe = navigation.addListener('focus', () => {
+			if (community_obj.deleted_list && community_obj.deleted_list.length && data != 'false') {
+				//삭제된 리뷰글 필터 적용
+				console.log('삭제된 리뷰글 필터 전용시작', community_obj.deleted_list.length);
+				try {
+					let temp = [...data];
+					temp = temp.filter(e => !community_obj.deleted_list.includes(e._id));
+					setData(temp);
+				} catch (err) {
+					console.log('err', err);
+				}
+			}
+		});
 		if (data != 'false' && data.length) {
 			data.map((v, i) => {
 				const find = community_obj.review.findIndex(e => e._id == v._id);
@@ -42,6 +51,7 @@ export default FavoriteReview = ({route, isFavorite}) => {
 				}
 			});
 		}
+		return unsubscribe;
 	}, [data]);
 
 	const fetchData = () => {
@@ -307,7 +317,7 @@ export default FavoriteReview = ({route, isFavorite}) => {
 			// 	<EmptyIcon />
 			// 	<Text style={[txt.noto28, {marginTop: 10 * DP}]}>{!isFavorite ? '작성한 리뷰글이 없습니다..' : '즐겨찾기한 리뷰가 없습니다..'} </Text>
 			// </View>
-			<ListEmptyInfo text={!isFavorite ? '작성한 자유게시글이 없습니다..' : '즐겨찾기한 리뷰글이 없습니다..'} />
+			<ListEmptyInfo text={!isFavorite ? '작성한 리뷰글이 없습니다..' : '즐겨찾기한 리뷰글이 없습니다..'} />
 		);
 	};
 

--- a/src/component/templete/feed/FeedCommentList.js
+++ b/src/component/templete/feed/FeedCommentList.js
@@ -23,6 +23,7 @@ export default FeedCommentList = props => {
 	const [editComment, setEditComment] = React.useState(false); //답글 쓰기 클릭 state
 	const [privateComment, setPrivateComment] = React.useState(false); // 공개 설정 클릭 state
 	const [comments, setComments] = React.useState([]);
+	const [commentsLoaded, setCommentsLoaded] = React.useState(false);
 	const [parentComment, setParentComment] = React.useState();
 	const [refresh, setRefresh] = React.useState(true);
 	const keyboardY = useKeyboardBottom(0 * DP);
@@ -59,6 +60,38 @@ export default FeedCommentList = props => {
 		}
 	}, []);
 
+	React.useEffect(() => {
+		if (commentsLoaded) {
+			comments.forEach((current, index) => {
+				if (params.parent) {
+					if (current._id == params.parent) {
+						setTimeout(
+							() =>
+								flatlist.current.scrollToIndex({
+									animated: true,
+									index: index,
+								}),
+
+							500,
+						);
+					}
+				} else {
+					if (current._id == params.target) {
+						setTimeout(
+							() =>
+								flatlist.current.scrollToIndex({
+									animated: true,
+									index: index,
+								}),
+
+							500,
+						);
+					}
+				}
+			});
+		}
+	}, [commentsLoaded]);
+
 	//댓글 리스트 api 접속
 	const fetchData = parent => {
 		getCommentListByFeedId(
@@ -82,6 +115,7 @@ export default FeedCommentList = props => {
 				}
 				setComments(res);
 				updateGlobal(res);
+				setCommentsLoaded(true);
 				setIsLoading(false);
 				if (params.edit && editFromDetailRef) {
 					//실종,제보 상세페이지에서 댓글 수정을 눌렀을 경우 해당 댓글로 스크롤 시도
@@ -478,8 +512,9 @@ export default FeedCommentList = props => {
 						data={params.feedobject}
 						deleteFeed={deleteFeedItem}
 						showAllContents={params.showAllContents}
+						showMedia={params.showMedia ? params.showMedia : false}
 						routeName={props.route.name}
-						showMedia={false}
+						// showMedia={false}
 					/>
 					<View style={[{width: 694 * DP, height: 2 * DP, marginTop: 10 * DP, backgroundColor: GRAY40, alignSelf: 'center'}]} />
 					<View style={[{width: 694 * DP, alignSelf: 'center', marginTop: 20 * DP}]}>
@@ -531,8 +566,11 @@ export default FeedCommentList = props => {
 					showChild={() => showChild(index)} //답글보기 열기
 					openChild={isOpen} //답글보기 열기 여부
 					editData={editData} //현재 수정 데이터
+					target={params.target}
+					parent={params.parent}
 					replyFromDetail={replyFromDetail} //실종,제보 상세의 댓글리스트에서 답글쓰기가 눌렸을 경우
 				/>
+				{index == comments.length - 1 && <View style={{height: 100 * DP, width: '100%'}} />}
 			</View>
 		);
 	};
@@ -565,7 +603,7 @@ export default FeedCommentList = props => {
 				ref={flatlist}
 			/>
 			{/* Parent Comment 혹은 Child Comment 에서 답글쓰기를 클릭할 시 화면 최하단에 등장 */}
-			{userGlobalObject.userInfo._id != '' && (editComment || props.route.name == 'FeedCommentList') ? (
+			{userGlobalObject.userInfo._id != '' ? (
 				<View style={{position: 'absolute', bottom: keyboardY - 2}} onLayout={onReplyBtnLayout}>
 					<ReplyWriteBox
 						onAddPhoto={onAddPhoto}

--- a/src/component/templete/feed/FeedWrite.js
+++ b/src/component/templete/feed/FeedWrite.js
@@ -246,6 +246,7 @@ export default FeedWrite = props => {
 					scrollref={scrollref}
 					currentScrollOffset={scrolloffset.current}
 					feedInput={feedInput}
+					moveToPhotoSelect={moveToMultiPhotoSelect}
 				/>
 			);
 		} // 긴급 게시 버튼 중 '실종' 클릭한 경우
@@ -260,6 +261,7 @@ export default FeedWrite = props => {
 					currentScrollOffset={scrolloffset.current}
 					feedInput={feedInput}
 					selectedImages={selectedImages}
+					moveToPhotoSelect={moveToMultiPhotoSelect}
 				/>
 			) : (
 				false

--- a/src/component/templete/feed/MissingForm.js
+++ b/src/component/templete/feed/MissingForm.js
@@ -442,7 +442,8 @@ export default MissingForm = props => {
 
 	//사진 추가
 	const moveToMultiPhotoSelect = () => {
-		navigation.navigate('MultiPhotoSelect', {prev: {name: route.name, key: route.key}});
+		// navigation.navigate('MultiPhotoSelect', {prev: {name: route.name, key: route.key}});
+		props.moveToPhotoSelect();
 	};
 
 	const feedInput = props.feedInput();
@@ -570,6 +571,7 @@ export default MissingForm = props => {
 					placeholderTextColor={GRAY10}
 					width={694}
 					height={104}
+					heightRatio={null}
 					descriptionType={'none'}
 					onChange={onChangeMissingLocationDetail}
 					maxlength={50}

--- a/src/component/templete/feed/ReportForm.js
+++ b/src/component/templete/feed/ReportForm.js
@@ -331,8 +331,8 @@ export default ReportForm = props => {
 
 	//사진 추가
 	const moveToMultiPhotoSelect = () => {
-		// props.moveToPhotoSelect();
-		navigation.navigate('MultiPhotoSelect', {prev: {name: route.name, key: route.key}});
+		props.moveToPhotoSelect();
+		// navigation.navigate('MultiPhotoSelect', {prev: {name: route.name, key: route.key}});
 	};
 
 	return (

--- a/src/component/templete/list/AlarmList.js
+++ b/src/component/templete/list/AlarmList.js
@@ -90,23 +90,12 @@ const AlarmList = props => {
 
 	const onLabelClick = data => {
 		console.log('target_object_type', data.target_object_type);
-		let navState = props.navigation.getState();
-		// console.log('navState', navState);
 		setNavLoading(true);
 		switch (data.target_object_type) {
-			case 'comment':
-				break;
 			case 'FollowObject':
 				getUserProfile(
 					{userobject_id: data.notice_user_related_id._id},
 					result => {
-						// console.log('result', result.msg);
-						// navigation.dispatch({
-						// 	...CommonActions.reset({
-						// 		index: 1,
-						// 		routes: [{name: 'MainTab'}, {name: 'AlarmList'}, {name: 'Profile', params: {userobject: result.msg}}],
-						// 	}),
-						// });
 						setNavLoading(false);
 						navigation.dispatch(
 							CommonActions.navigate({
@@ -131,34 +120,42 @@ const AlarmList = props => {
 				);
 				break;
 			case 'FeedObject':
+				// console.log('data.notice_object_type', data);
 				if (data.notice_object_type == 'LikeFeedObject') {
 					var selected = {_id: data.target_object};
 					getUserProfile(
 						{userobject_id: data.notice_user_receive_id},
 						result => {
-							// navigation.dispatch({
-							// 	...CommonActions.reset({
-							// 		index: 1,
-							// 		routes: [{name: 'MainTab'}, {name: 'AlarmList'}, {name: 'UserFeedList', params: {userobject: result.msg, selected: selected}}],
-							// 	}),
-							// });
-							setNavLoading(false);
-							navigation.dispatch(
-								CommonActions.navigate({
-									name: 'UserFeedList',
-									params: {userobject: result.msg, selected: selected},
-								}),
+							getFeedDetailById(
+								{feedobject_id: data.target_object},
+								res => {
+									setNavLoading(false);
+									navigation.dispatch(
+										CommonActions.navigate({
+											name: 'UserFeedList',
+											params: {userobject: result.msg, selected: selected},
+										}),
+									);
+								},
+								err => {
+									setNavLoading(false);
+									console.log('getFeedDetail err', err);
+									if (err.includes('없습니다')) {
+										Modal.alert('이미 삭제된 게시글입니다.', Modal.close);
+									}
+								},
 							);
 						},
 						err => {
 							setNavLoading(false);
-							console.log('err /', err);
+							console.log('err / FeedObject', err);
 						},
 					);
 				} else if (data.notice_object_type == 'CommentObject') {
 					getFeedDetailById(
 						{feedobject_id: data.target_object},
 						result => {
+							console.log(navigation.getState());
 							setNavLoading(false);
 							navigation.dispatch(
 								CommonActions.navigate({
@@ -167,6 +164,7 @@ const AlarmList = props => {
 									params: {
 										feedobject: result.msg,
 										showAllContents: true,
+										showMedia: true,
 										scroll: true,
 										target: data.notice_object,
 										parent: data?.notice_comment_parent,
@@ -185,22 +183,28 @@ const AlarmList = props => {
 				}
 				break;
 			case 'FeedUserTagObject':
-				var selected = {_id: data.target_object};
-				// console.log('selected', selected);
-				getUserProfile(
-					{userobject_id: data.notice_user_related_id._id},
+				var selected = {_id: data.notice_object};
+				// console.log('FeedUserTagObject data', data);
+				getFeedDetailById(
+					{feedobject_id: data.notice_object},
 					result => {
 						setNavLoading(false);
 						navigation.dispatch(
 							CommonActions.navigate({
 								name: 'UserFeedList',
-								params: {userobject: result.msg, selected: selected},
+								params: {
+									userobject: {_id: data.notice_user_related_id._id, user_nickname: data.notice_user_related_id.user_nickname},
+									selected: selected,
+								},
 							}),
 						);
 					},
 					err => {
-						console.log('err', err);
 						setNavLoading(false);
+						console.log('getFeedDetail err', err);
+						if (err.includes('없습니다')) {
+							Modal.alert('이미 삭제된 게시글입니다.', Modal.close);
+						}
 					},
 				);
 				break;
@@ -244,7 +248,7 @@ const AlarmList = props => {
 				);
 				break;
 			case 'CommunityObject':
-				console.log('data.target', data.target_object);
+				console.log('data.target', data);
 				getCommunityByObjectId(
 					{community_object_id: data.target_object},
 					result => {
@@ -259,7 +263,8 @@ const AlarmList = props => {
 					},
 					err => {
 						setNavLoading(false);
-						console.log('err', err);
+						console.log('err / CommunityObject', err);
+						Modal.alert('이미 삭제된 게시물입니다.');
 					},
 				);
 				break;

--- a/src/component/templete/profile/Profile.js
+++ b/src/component/templete/profile/Profile.js
@@ -481,15 +481,19 @@ export default Profile = ({route}) => {
 						/>
 					);
 				} else if (tabMenuSelected == 1) {
-					return (
-						<FeedThumbnailList
-							items={item}
-							whenEmpty={whenFeedThumbnailEmpty('태그된 게시물이 없습니다.')}
-							onClickThumnail={onClick_Thumbnail_TagTab}
-							onEndReached={() => onEndReached(tabMenuSelected)}
-							focused={focused}
-						/>
-					);
+					if (tagFeedList != 'false') {
+						return (
+							<FeedThumbnailList
+								items={item}
+								whenEmpty={whenFeedThumbnailEmpty('태그된 게시물이 없습니다.')}
+								onClickThumnail={onClick_Thumbnail_TagTab}
+								onEndReached={() => onEndReached(tabMenuSelected)}
+								focused={focused}
+							/>
+						);
+					} else {
+						return <></>;
+					}
 				} else {
 					return <CommunityList user_id={route.params.userobject._id} />;
 				}
@@ -504,14 +508,19 @@ export default Profile = ({route}) => {
 						/>
 					);
 				} else if (tabMenuSelected == 1) {
-					return (
-						<FeedThumbnailList
-							items={item}
-							whenEmpty={whenFeedThumbnailEmpty('태그된 게시물이 없습니다.')}
-							onClickThumnail={onClick_Thumbnail_TagTab}
-							focused={focused}
-						/>
-					);
+					if (tagFeedList != 'false') {
+						return (
+							<FeedThumbnailList
+								items={item}
+								whenEmpty={whenFeedThumbnailEmpty('태그된 게시물이 없습니다.')}
+								onClickThumnail={onClick_Thumbnail_TagTab}
+								onEndReached={() => onEndReached(tabMenuSelected)}
+								focused={focused}
+							/>
+						);
+					} else {
+						return <></>;
+					}
 				}
 			} else if (data.user_type == 'shelter') {
 				//보호소 계정

--- a/src/component/templete/search/SearchArticle.js
+++ b/src/component/templete/search/SearchArticle.js
@@ -72,7 +72,11 @@ export default SearchArticle = props => {
 		} else if (onlyMeeting) {
 			filtered = filtered.filter(e => e.community_free_type == 'meeting');
 		}
-		return filtered;
+		const reverse = [];
+		for (let i = filtered.length - 1; i >= 0; i--) {
+			reverse.push(filtered[i]);
+		}
+		return reverse;
 	};
 
 	const whenEmpty = () => {

--- a/src/component/templete/search/SearchReview.js
+++ b/src/component/templete/search/SearchReview.js
@@ -267,7 +267,11 @@ export default SearchReview = props => {
 		if (!filterData.dog && !filterData.cat && !filterData.etc) {
 			filtered = data;
 		}
-		return filtered;
+		const reverse = [];
+		for (let i = filtered.length - 1; i >= 0; i--) {
+			reverse.push(filtered[i]);
+		}
+		return reverse;
 	};
 
 	const filterComponent = () => {

--- a/src/component/templete/user/UserMenu.js
+++ b/src/component/templete/user/UserMenu.js
@@ -66,7 +66,7 @@ export default UserMenu = props => {
 			userObject => {
 				// console.log('user', userObject.msg.user_my_pets);
 				setData(userObject.msg);
-				console.log('userObjedt intro', userObject.msg.user_introduction.replace(/[\r\n]/gm, ''));
+				// console.log('userObjedt intro', userObject.msg.user_introduction.replace(/[\r\n]/gm, ''));
 			},
 
 			err => {

--- a/src/navigation/header/CommunityHeader.js
+++ b/src/navigation/header/CommunityHeader.js
@@ -78,25 +78,13 @@ export default CommunityHeader = ({navigation, route, options, back}) => {
 												community_is_delete: true,
 											},
 											result => {
-												// console.log('result / updateAndDeleteCommunity / ArticleDetail : ', result.msg);
+												// console.log('result / updateAndDeleteCommunity / CommunityHeader : ', result.msg);
 												Modal.close();
 												community_obj.review = community_obj.review.filter(e => e._id == data._id);
-												community_obj.deleted_list.push(result.msg);
 												setTimeout(() => {
 													Modal.popNoBtn('게시글 삭제가 완료되었습니다.');
-													setTimeout(() => {
-														Modal.close();
-														navigation.goBack();
-														// data.community_type == 'review'
-														// 	? navigation.reset({
-														// 			index: 0,
-														// 			routes: [{name: 'CommunityMain', params: {isReview: true}}],
-														// 	  })
-														// 	: navigation.reset({
-														// 			index: 0,
-														// 			routes: [{name: 'CommunityMain', params: {isReview: false}}],
-														// 	  });
-													}, 600);
+													community_obj.deleted_list.push(result.msg._id);
+													navigation.goBack();
 												}, 200);
 											},
 											err => {

--- a/src/navigation/header/CommunityHeader.js
+++ b/src/navigation/header/CommunityHeader.js
@@ -81,19 +81,21 @@ export default CommunityHeader = ({navigation, route, options, back}) => {
 												// console.log('result / updateAndDeleteCommunity / ArticleDetail : ', result.msg);
 												Modal.close();
 												community_obj.review = community_obj.review.filter(e => e._id == data._id);
+												community_obj.deleted_list.push(result.msg);
 												setTimeout(() => {
 													Modal.popNoBtn('게시글 삭제가 완료되었습니다.');
 													setTimeout(() => {
 														Modal.close();
-														data.community_type == 'review'
-															? navigation.reset({
-																	index: 0,
-																	routes: [{name: 'CommunityMain', params: {isReview: true}}],
-															  })
-															: navigation.reset({
-																	index: 0,
-																	routes: [{name: 'CommunityMain', params: {isReview: false}}],
-															  });
+														navigation.goBack();
+														// data.community_type == 'review'
+														// 	? navigation.reset({
+														// 			index: 0,
+														// 			routes: [{name: 'CommunityMain', params: {isReview: true}}],
+														// 	  })
+														// 	: navigation.reset({
+														// 			index: 0,
+														// 			routes: [{name: 'CommunityMain', params: {isReview: false}}],
+														// 	  });
 													}, 600);
 												}, 200);
 											},

--- a/src/navigation/route/main_tab/community_stack/CommunityMainStack.js
+++ b/src/navigation/route/main_tab/community_stack/CommunityMainStack.js
@@ -34,6 +34,7 @@ import PhotoSelectHeader from 'Root/navigation/header/PhotoSelectHeader';
 import SimpleWithMeatballHeader from 'Root/navigation/header/SimpleWithMeatballHeader';
 import ReportDetail from 'Root/component/templete/missing/ReportDetail';
 import MissingAnimalDetail from 'Root/component/templete/missing/MissingAnimalDetail';
+import FeedCommentList from 'Root/component/templete/feed/FeedCommentList';
 
 const CommunityMainStackNavi = createStackNavigator();
 
@@ -159,7 +160,7 @@ export default CommunityMainStack = props => {
 
 			{/* 알람용 */}
 			<CommunityMainStackNavi.Screen name="AlarmList" component={AlarmList} options={{header: props => <SimpleHeader {...props} />, title: '소식'}} />
-			<CommunityMainStackNavi.Screen name="AlarmCommentList" component={AlarmCommentList} options={{header: props => <SimpleHeader {...props} />}} />
+			<CommunityMainStackNavi.Screen name="AlarmCommentList" component={FeedCommentList} options={{header: props => <SimpleHeader {...props} />}} />
 			<CommunityMainStackNavi.Screen
 				name="ShelterVolunteerForm"
 				component={ApplicationFormVolunteer}

--- a/src/navigation/route/main_tab/feed_stack/FeedStackNavigation.js
+++ b/src/navigation/route/main_tab/feed_stack/FeedStackNavigation.js
@@ -73,11 +73,7 @@ export default FeedStackNavigation = props => {
 				options={{header: props => <SimpleHeader {...props} />, title: '프로필 변경'}}
 			/>
 			<FeedStack.Screen name="AlarmList" component={AlarmList} options={{header: props => <SimpleHeader {...props} />, title: '소식'}} />
-			<FeedStack.Screen
-				name="AlarmCommentList"
-				component={AlarmCommentList}
-				options={{header: props => <SimpleHeader {...props} />, title: '댓글'}}
-			/>
+			<FeedStack.Screen name="AlarmCommentList" component={FeedCommentList} options={{header: props => <SimpleHeader {...props} />, title: '댓글'}} />
 			<FeedStack.Screen
 				name={'CommunityCommentList'}
 				component={CommunityCommentList}

--- a/src/navigation/route/main_tab/feed_stack/FeedStackNavigation.js
+++ b/src/navigation/route/main_tab/feed_stack/FeedStackNavigation.js
@@ -137,6 +137,7 @@ export default FeedStackNavigation = props => {
 			/>
 			<FeedStack.Screen name="ReportDetail" component={ReportDetail} options={{header: props => <SimpleWithMeatballHeader {...props} />}} />
 			<FeedStack.Screen name="SinglePhotoSelect" component={AddPhoto} options={{header: props => <PhotoSelectHeader {...props} />, title: ''}} />
+			<FeedStack.Screen name="MultiPhotoSelect" component={AddPhoto} options={{header: props => <PhotoSelectHeader {...props} />, title: ''}} />
 			<FeedStack.Screen
 				name={'CommunityEdit'}
 				component={CommunityEdit}

--- a/src/navigation/route/main_tab/my_stack/MyStackNavigation.js
+++ b/src/navigation/route/main_tab/my_stack/MyStackNavigation.js
@@ -384,7 +384,7 @@ export default MyStackNavigation = props => {
 			<MyStack.Screen name="MyArticle" component={FavoriteArticle} options={{header: props => <SimpleHeader {...props} />, title: '나의 자유글'}} />
 			<MyStack.Screen name="MyReview" component={FavoriteReview} options={{header: props => <SimpleHeader {...props} />, title: '나의 리뷰'}} />
 			<MyStack.Screen name="AlarmList" component={AlarmList} options={{header: props => <SimpleHeader {...props} />, title: '소식'}} />
-			<MyStack.Screen name="AlarmCommentList" component={AlarmCommentList} options={{header: props => <SimpleHeader {...props} />}} />
+			<MyStack.Screen name="AlarmCommentList" component={FeedCommentList} options={{header: props => <SimpleHeader {...props} />}} />
 			<MyStack.Screen
 				name={'CommunityCommentList'}
 				component={CommunityCommentList}

--- a/src/navigation/route/main_tab/protection_stack/ProtectionStackNavigation.js
+++ b/src/navigation/route/main_tab/protection_stack/ProtectionStackNavigation.js
@@ -124,7 +124,7 @@ export default ProtectionStackNavigation = props => {
 			/>
 			{/* 알람용 */}
 			<ProtectionStack.Screen name="AlarmList" component={AlarmList} options={{header: props => <SimpleHeader {...props} />, title: '소식'}} />
-			<ProtectionStack.Screen name="AlarmCommentList" component={AlarmCommentList} options={{header: props => <SimpleHeader {...props} />}} />
+			<ProtectionStack.Screen name="AlarmCommentList" component={FeedCommentList} options={{header: props => <SimpleHeader {...props} />}} />
 			<ProtectionStack.Screen name="UserNotePage" component={UserNotePage} options={{header: props => <SimpleHeader {...props} />}} />
 			<ProtectionStack.Screen
 				name={'ArticleDetail'}

--- a/src/navigation/route/search_tab/SearchMainStack.js
+++ b/src/navigation/route/search_tab/SearchMainStack.js
@@ -76,6 +76,7 @@ export default SearchMainStack = props => {
 				options={{header: props => <SimpleHeader {...props} />, title: '댓글'}}
 			/>
 			<SearchStackNav.Screen name="SinglePhotoSelect" component={AddPhoto} options={{header: props => <PhotoSelectHeader {...props} />, title: ''}} />
+			<SearchStackNav.Screen name="MultiPhotoSelect" component={AddPhoto} options={{header: props => <PhotoSelectHeader {...props} />, title: ''}} />
 			<SearchStackNav.Screen
 				name="FeedListForHashTag"
 				component={FeedListForHashTag}


### PR DESCRIPTION
*수정 사항: 
*수정 결과: 
*수정 파일:
1) src/component/molecules/input/Input24.js
    src/component/templete/feed/MissingForm.js
- 2-3_버전 0706-15:40_발견 0707_최하늘: iOS > 실종/제보 글쓰기 > 실종 위치 > 상세 위치 기재하는 인풋 가로를 넘도록 기재할 경우 n줄로 출력되는데, 인풋 크기는 그만큼 커지지 않아서 글자가 잘려 보임
- height를 가변으로 줄 수 있도록 props 추가

2) src/component/templete/favorite/FavoriteArticle.js
- 페이지가 포커스 될 시 삭제된 게시글이 필터되도록 수정
- 리뷰글 페이지에서도 '작성한 자유게시글이 없습니다'로 출력되던 현상 수정

3) src/component/templete/feed/FeedCommentList.js
    src/component/templete/list/AlarmList.js
    src/navigation/route/main_tab/community_stack/CommunityMainStack.js
    src/navigation/route/main_tab/feed_stack/FeedStackNavigation.js
    src/navigation/route/main_tab/my_stack/MyStackNavigation.js
    src/navigation/route/main_tab/protection_stack/ProtectionStackNavigation.js
- 별도로 존재하던 AlarmCommentList를  FeedCommentList로 통합
- 알람리스트에서 삭제된 게시글로도 이동이 가능하던 현상 수정

4) src/component/templete/profile/Profile.js
- 프로필 홈에서 태그된 피드리스트 탭을 처음 누를 경우 5개의 검은 바탕의 피드썸네일리스트가 잠시간 출력되는 현상 수정

5) src/component/templete/search/SearchArticle.js
     src/component/templete/search/SearchReview.js
- 검색된 목록이 예전글부터 출력되던 현상 발견 -> 우선 클라이언트에서 역순으로 정렬해서 출력토록 적용

6) src/navigation/header/CommunityHeader.js
- 커뮤니티 삭제 시 전역관리리스트에 반영되도록 수정

7) src/navigation/route/search_tab/SearchMainStack.js
- 검색탭에서 글쓰기 시도=> 사진 추가 => 다시 글쓰기 화면으로 돌아올 시 간헐적으로 앱이 강제종료되던 현상 수정
- 검색 스택 스크린에 MultiPhotoSelect ㅅ크린 추가

