### PR TITLE
[상우] UI 테스트 오류사항 수정

### DIFF
--- a/src/component/molecules/media/FeedMedia.js
+++ b/src/component/molecules/media/FeedMedia.js
@@ -53,33 +53,31 @@ export default FeedMedia = props => {
 		feed_comment_count,
 		feed_writer_id,
 		feed_avatar_id,
+		_id,
 	} = props.data;
 
 	const navigation = useNavigation();
 	const [data, setData] = React.useState(props.data);
 	const emergency_title = feed_type == 'report' ? '제보' : feed_type == 'missing' ? '실종' : '';
-	const isEmergency = feed_type == 'report' || feed_type == 'missing';
-	const animal_species = missing_animal_species || report_animal_species;
-	const species_detail = missing_animal_species_detail || report_animal_species_detail;
-	const animal_species_detail = species_detail?.includes('un') || !species_detail ? '' : ' / ' + species_detail;
-	const emergency_location = missing_animal_lost_location || report_witness_location;
 	const contentParsing = feed_content.replace(/(&[#|@]){2}(.*?)%&%.*?(&[#|@]){2}/g, '$2');
 
 	let newMissingDate = '';
-	let splitAddress = '';
 	let newMissingAddress = '';
 
 	React.useEffect(() => {
-		const unsubscribe = navigation.addListener('focus', () => {
-			const findIndex = feed_obj.list.findIndex(e => e._id == props.data._id);
-			if (findIndex != -1) {
-				if (feed_obj.shouldUpdateByEdit && feed_obj.edit_obj && feed_obj.edit_obj._id == props.data._id) {
-					console.log(';feed_obj.edit_obj', feed_obj.edit_obj?.report_witness_location);
-					setData(feed_obj.edit_obj);
+		try {
+			const unsubscribe = navigation.addListener('focus', () => {
+				const findIndex = feed_obj.list.findIndex(e => e._id == props.data._id);
+				const isEditedList = feed_obj.edited_list.map(v => v._id).includes(props.data._id);
+				if (findIndex != -1 && isEditedList) {
+					const edited_index = feed_obj.edited_list.findIndex(e => e._id == _id);
+					setData(feed_obj.edited_list[edited_index]);
 				}
-			}
-		});
-		return unsubscribe;
+			});
+			return unsubscribe;
+		} catch (err) {
+			console.log('err', err);
+		}
 	}, []);
 
 	if (feed_type == 'missing') {
@@ -110,37 +108,11 @@ export default FeedMedia = props => {
 			console.log('err', err);
 		}
 	}
-	// console.log(props.data.medias);
-	const onSelect = () => {
-		props.onSelect(props.data.feed_id);
-		// setSelected(!selected);
-	};
 
-	const getFeedIcon = () => {
-		//data.medias의 값들 중 video형식의 media가 하나 이상 존재하는 경우
-		if (feed_medias.some(v => v.isVideo == 'video')) {
-			return (
-				<View style={{position: 'absolute', top: 290 * DP, left: 328 * DP}}>
-					<VideoPlay_Feed />
-				</View>
-			);
-			//data.medias 배열의 길이가 1개 이상인 경우
-		} else if (feed_medias.length > 1) {
-			return (
-				<View style={{position: 'absolute', top: 20 * DP, left: 20 * DP}}>
-					<ImageList48 />
-				</View>
-			);
-		} else return false;
-	};
-
-	const onPressPhoto = (uri) => {
-		console.log(feed_medias)
-		let list = feed_medias.filter(v=>!v.is_video&&v.media_uri!=uri)
-		Modal.popPhotoListViewModal(
-			[uri].concat(list.map(v=>v.media_uri)),
-			() => Modal.close(),
-		);
+	const onPressPhoto = uri => {
+		console.log(feed_medias);
+		let list = feed_medias.filter(v => !v.is_video && v.media_uri != uri);
+		Modal.popPhotoListViewModal([uri].concat(list.map(v => v.media_uri)), () => Modal.close());
 	};
 
 	const onPressImg = () => {
@@ -179,7 +151,7 @@ export default FeedMedia = props => {
 					renderPagination={pagenation}
 					onIndexChanged={indexChange}
 					horizontal={true}>
-					{feed_medias.map((data, idx) => {
+					{data.feed_medias.map((data, idx) => {
 						return (
 							<React.Fragment key={idx}>
 								<PhotoTagItem

--- a/src/component/molecules/media/ProtectedThumbnail.js
+++ b/src/component/molecules/media/ProtectedThumbnail.js
@@ -16,8 +16,6 @@ import feed_obj from 'Root/config/feed_obj';
  * @param {boolean} props.inActiveOpacity - 전시용일 경우 Touch 액션 제거
  */
 const ProtectedThumbnail = props => {
-	// console.log('props ProtectThumb', props.data);
-	// const data = props.data;
 	const navigation = useNavigation();
 	const [data, setData] = React.useState(props.data);
 
@@ -25,8 +23,10 @@ const ProtectedThumbnail = props => {
 	React.useEffect(() => {
 		const unsubscribe = navigation.addListener('focus', () => {
 			try {
-				if (feed_obj.shouldUpdateByEdit && feed_obj.edit_obj && feed_obj.edit_obj._id == props.data._id) {
-					setData({...data, img_uri: feed_obj.edit_obj.feed_thumbnail});
+				const isEditedList = feed_obj.edited_list.map(v => v._id).includes(props.data._id);
+				if (feed_obj.shouldUpdateByEdit && isEditedList) {
+					const edited_index = feed_obj.edited_list.findIndex(e => e._id == props.data._id);
+					setData({...data, img_uri: feed_obj.edited_list[edited_index].feed_thumbnail});
 				}
 			} catch (err) {
 				console.log('err', err);

--- a/src/component/molecules/modal/OneButtonSelectModal.js
+++ b/src/component/molecules/modal/OneButtonSelectModal.js
@@ -34,6 +34,7 @@ const OneButtonSelectModal = props => {
 	};
 	// console.log('modal props', props);
 	const [selectedItem, setSelectedItem] = React.useState(2);
+	const [confirmIndex, setConfirmIndex] = React.useState(2);
 	const [confirmedSelect, setConfirmedSelect] = React.useState(data[2]);
 	const [selectOpen, setSelectOpen] = React.useState(false);
 	const [directInput, setDirectInput] = React.useState('');
@@ -66,7 +67,7 @@ const OneButtonSelectModal = props => {
 		} else {
 			if (focused >= data.length) {
 				// 마지막 배열을 넘어서서 스크롤을 할 경우 마지막으로 자동 회귀
-				console.log('focused', focused);
+				// console.log('focused', focused);
 				setSelectedItem(data.length + 1);
 			} else {
 				setSelectedItem(focused + 2);
@@ -147,6 +148,10 @@ const OneButtonSelectModal = props => {
 
 	const onPressOutSide = () => {
 		if (selectOpen) {
+			console.log('s', selectedItem);
+			setConfirmIndex(selectedItem);
+			setSelectedItem(selectedItem);
+			setConfirmedSelect(data[selectedItem - 2]);
 			setSelectOpen(!selectOpen);
 		} else if (key) {
 			Keyboard.dismiss();
@@ -162,7 +167,7 @@ const OneButtonSelectModal = props => {
 				<Text style={[txt.noto28, style.msg]}>{props.msg}</Text>
 				<TouchableOpacity onPress={onOpen} style={style.dropdownContainer} activeOpacity={1}>
 					<View style={[style.selectedItem, {justifyContent: 'center', flexDirection: 'row'}]}>
-						<Text style={[txt.noto28, {fontSize: props.fontSize * DP - 5}]}>{data[selectedItem - 2]}</Text>
+						<Text style={[txt.noto28, {fontSize: props.fontSize * DP - 5}]}>{data[confirmIndex - 2]}</Text>
 						<View style={style.dropdownIcon}>{!selectOpen ? <Arrow_Down_GRAY10 onPress={onOpen} /> : <Arrow_Up_GRAY10 onPress={onOpen} />}</View>
 					</View>
 				</TouchableOpacity>
@@ -229,7 +234,7 @@ const style = StyleSheet.create({
 		width: Platform.OS == 'ios' ? Dimensions.get('window').width : '100%',
 		// justifyContent: 'center',
 		// top: 200 * DP,
-		paddingTop: 552 * DP,
+		paddingTop: 400 * DP,
 		alignItems: 'center',
 	},
 	popUpWindow: {

--- a/src/component/organism/feed/PhotoTagItem.js
+++ b/src/component/organism/feed/PhotoTagItem.js
@@ -44,6 +44,12 @@ export default PhotoTagItem = ({
 	const tagBackground = React.useRef();
 	const [mute, setMute] = React.useState(true);
 	const [play, setPlay] = React.useState(false);
+
+	//피드가 수정될 시 피드 갱신
+	React.useEffect(() => {
+		setTags(taglist);
+	}, [taglist]);
+
 	const makeTag = e => {
 		clickedPost.current = {x: e.nativeEvent.locationX, y: e.nativeEvent.locationY};
 		console.log(clickedPost.current);
@@ -147,27 +153,27 @@ export default PhotoTagItem = ({
 	};
 	const videoPause = () => {
 		Animated.sequence([
-			Animated.timing(fadeAnimPause,{
-				toValue:1,
-				duration:fadePauseDuration/3,
-				useNativeDriver:true
+			Animated.timing(fadeAnimPause, {
+				toValue: 1,
+				duration: fadePauseDuration / 3,
+				useNativeDriver: true,
 			}),
-			Animated.timing(fadeAnimPause,{
-				toValue:0,
-				duration:fadePauseDuration/3,
-				useNativeDriver:true
-			})
-		]).start()
-		setTimeout(()=>{
-			setPlay(false)
-		},fadePauseDuration+100)
+			Animated.timing(fadeAnimPause, {
+				toValue: 0,
+				duration: fadePauseDuration / 3,
+				useNativeDriver: true,
+			}),
+		]).start();
+		setTimeout(() => {
+			setPlay(false);
+		}, fadePauseDuration + 100);
 	};
 
-	React.useEffect(()=>{
-		if(!onShow){
+	React.useEffect(() => {
+		if (!onShow) {
 			setPlay(false);
 		}
-	},[onShow])
+	}, [onShow]);
 
 	const video = () => {
 		return (
@@ -176,7 +182,7 @@ export default PhotoTagItem = ({
 					<Video
 						style={[styles.img_square_round_694, {backgroundColor: '#000'}]}
 						source={{uri: uri}}
-						paused={!play&&viewmode}
+						paused={!play && viewmode}
 						muted={mute}
 						useTextureView={Platform.OS != 'android'}
 						repeat={true}
@@ -197,35 +203,37 @@ export default PhotoTagItem = ({
 				) : (
 					<View style={[styles.img_square_round_694, {backgroundColor: '#000'}]} />
 				)}
-				{viewmode&&<View style={{position: 'absolute'}}>
-					{!play ? (
-						<TouchableWithoutFeedback onPress={videoplay}>
-							<Animated.View
-								style={{
-									width: 750 * DP,
-									height: 750 * DP,
-									justifyContent: 'center',
-									alignItems: 'center',
-									opacity: fadeAnimPlay,
-								}}>
-								<VideoPlay />
-							</Animated.View>
-						</TouchableWithoutFeedback>
-					) : (
-						<TouchableWithoutFeedback onPress={videoPause}>
-							<Animated.View
-								style={{
-									width: 750 * DP,
-									height: 750 * DP,
-									justifyContent: 'center',
-									alignItems: 'center',
-									opacity: fadeAnimPause,
-								}}>
-								<VideoPause />
-							</Animated.View>
-						</TouchableWithoutFeedback>
-					)}
-				</View>}
+				{viewmode && (
+					<View style={{position: 'absolute'}}>
+						{!play ? (
+							<TouchableWithoutFeedback onPress={videoplay}>
+								<Animated.View
+									style={{
+										width: 750 * DP,
+										height: 750 * DP,
+										justifyContent: 'center',
+										alignItems: 'center',
+										opacity: fadeAnimPlay,
+									}}>
+									<VideoPlay />
+								</Animated.View>
+							</TouchableWithoutFeedback>
+						) : (
+							<TouchableWithoutFeedback onPress={videoPause}>
+								<Animated.View
+									style={{
+										width: 750 * DP,
+										height: 750 * DP,
+										justifyContent: 'center',
+										alignItems: 'center',
+										opacity: fadeAnimPause,
+									}}>
+									<VideoPause />
+								</Animated.View>
+							</TouchableWithoutFeedback>
+						)}
+					</View>
+				)}
 				<View style={{position: 'absolute', top: 20 * DP, left: 20 * DP}}>
 					{mute ? <VideoMute66 onPress={toggleMute} /> : <VideoSound66 onPress={toggleMute} />}
 				</View>

--- a/src/component/organism/listitem/MissingReportItem.js
+++ b/src/component/organism/listitem/MissingReportItem.js
@@ -45,13 +45,15 @@ export default MissingReportItem = React.memo(props => {
 		const unsubscribe = navigation.addListener('focus', () => {
 			try {
 				const findIndex = feed_obj.list.findIndex(e => e._id == props.data._id);
-				if (feed_obj.shouldUpdateByEdit && feed_obj.edit_obj && feed_obj.edit_obj._id == props.data._id) {
-					setData({...feed_obj.edit_obj, is_favorite: findIndex != -1 ? feed_obj.list[findIndex].is_favorite : feed_obj.edit_obj.is_favorite});
+				const isEditedList = feed_obj.edited_list.map(v => v._id).includes(props.data._id);
+				if (feed_obj.shouldUpdateByEdit && isEditedList) {
+					const edited_index = feed_obj.edited_list.findIndex(e => e._id == props.data._id);
+					setData(feed_obj.edited_list[edited_index]);
 				} else if (findIndex != -1) {
 					setData({...data, is_favorite: feed_obj.list[findIndex].is_favorite});
 				}
 			} catch (err) {
-				console.log('err', err);
+				console.log('err MissingReport', err);
 			}
 		});
 		return unsubscribe;

--- a/src/component/templete/community/CommunityEdit.js
+++ b/src/component/templete/community/CommunityEdit.js
@@ -327,10 +327,10 @@ export default CommunityEdit = props => {
 	};
 
 	//리뷰글쓰기 버튼 아이콘 컨테이너
-	const getReviewButtonContainer = () => {
+	const getReviewButtonContainer = key => {
 		return (
 			<>
-				<TouchableOpacity onPress={onPressPhotoSelect} style={[style.buttonItem_review]}>
+				<TouchableOpacity onPress={() => onPressPhotoSelect(key)} style={[style.buttonItem_review]}>
 					<Camera54 />
 				</TouchableOpacity>
 				<View style={{height: 38 * DP, width: 2 * DP, backgroundColor: GRAY10, alignSelf: 'center', marginHorizontal: 30 * DP}}></View>
@@ -505,7 +505,7 @@ export default CommunityEdit = props => {
 				{isReview ? (
 					<View style={[style.animalFilter_container]}>
 						<View style={[style.animalFilter]}>
-							<View style={[style.buttonContainer_review, {opacity: showBtn == true ? 0 : 1, zIndex: 1}]}>{getReviewButtonContainer()}</View>
+							<View style={[style.buttonContainer_review, {opacity: showBtn == true ? 0 : 1, zIndex: 1}]}>{getReviewButtonContainer(true)}</View>
 							<View style={{flexDirection: 'row', width: 399 * DP, justifyContent: 'space-between'}}>
 								<View style={[]}>
 									{!animalType.dog ? (
@@ -555,7 +555,7 @@ export default CommunityEdit = props => {
 							zIndex: showBtn ? 3 : -1,
 						},
 					]}>
-					{getReviewButtonContainer()}
+					{getReviewButtonContainer(false)}
 				</View>
 			) : (
 				<View style={[style.buttonContainer_keyboard, {bottom: Platform.OS == 'android' ? 0 : KeyboardY, opacity: showBtn == false ? 0 : 1}]}>

--- a/src/component/templete/feed/FeedCommentList.js
+++ b/src/component/templete/feed/FeedCommentList.js
@@ -138,30 +138,23 @@ export default FeedCommentList = props => {
 	};
 
 	const updateGlobal = res => {
-		console.log('updateGlobal');
 		setIsLoading(false);
 		Modal.close();
-		let recent = res[0]; //가장 최근 댓글
 		let comment_count = res.length; //부모 댓글 총개수
 		res.map((v, i) => {
 			comment_count = comment_count + v.children_count; //자식 댓글있으면 부모 댓글 개수에 추가시킴
 		});
 		let temp = feed_obj.list; //현재 저장된 리스트
-		// console.log('temp', temp);
-		// console.log('comment_count', comment_count);
-		// console.log('params', params.feedobject.feed_comment_count, 'res length', res.length);
-		// console.log('fdd', feed_obj.list.length);
 		const findIndex = temp.findIndex(e => e._id == params.feedobject._id); //현재 보고 있는 피드게시글이 저장된 리스트에서 몇 번째인지
-		// console.log('find', findIndex);
 		temp[findIndex].feed_comment_count = comment_count; //해당 피드게시글의 댓글 개수 갱신
-		temp[findIndex].feed_recent_comment = {
-			//해당 피드게시글의 최근 댓글 갱신
-			comment_contents: recent.comment_contents,
-			comment_id: recent._id,
-			comment_user_nickname: recent.comment_writer_id.user_nickname,
-		};
+		// let recent = res[0]; //가장 최근 댓글
+		// temp[findIndex].feed_recent_comment = {
+		// 	//해당 피드게시글의 최근 댓글 갱신
+		// 	comment_contents: recent.comment_contents,
+		// 	comment_id: recent._id,
+		// 	comment_user_nickname: recent.comment_writer_id.user_nickname,
+		// };
 		feed_obj.list = [...temp]; //갱신
-		feed_obj.shouldUpdateByComment = true; //수정모드 true
 	};
 
 	//답글 쓰기 => Input 작성 후 보내기 클릭 콜백 함수
@@ -513,8 +506,8 @@ export default FeedCommentList = props => {
 						deleteFeed={deleteFeedItem}
 						showAllContents={params.showAllContents}
 						showMedia={params.showMedia ? params.showMedia : false}
+						isComment={true}
 						routeName={props.route.name}
-						// showMedia={false}
 					/>
 					<View style={[{width: 694 * DP, height: 2 * DP, marginTop: 10 * DP, backgroundColor: GRAY40, alignSelf: 'center'}]} />
 					<View style={[{width: 694 * DP, alignSelf: 'center', marginTop: 20 * DP}]}>

--- a/src/component/templete/user/UserInfoSetting.js
+++ b/src/component/templete/user/UserInfoSetting.js
@@ -507,7 +507,7 @@ export default UserInfoSetting = ({route}) => {
 									onClear={onClearNickname}
 									maxlength={12}
 								/>
-								<Text>*띄어쓰기 없이 2자 이상 15자 이내의 한글, 영문, 숫자, '_' 의 입력만 가능합니다.</Text>
+								<Text>*띄어쓰기 없이 2자 이상 12자 이내의 한글, 영문, 숫자, '_' 의 입력만 가능합니다.</Text>
 							</View>
 						</View>
 					) : (

--- a/src/component/templete/user/UserInfoSetting.js
+++ b/src/component/templete/user/UserInfoSetting.js
@@ -505,7 +505,7 @@ export default UserInfoSetting = ({route}) => {
 									width={694}
 									height={104}
 									onClear={onClearNickname}
-									maxlength={20}
+									maxlength={12}
 								/>
 								<Text>*띄어쓰기 없이 2자 이상 15자 이내의 한글, 영문, 숫자, '_' 의 입력만 가능합니다.</Text>
 							</View>

--- a/src/config/feed_obj.js
+++ b/src/config/feed_obj.js
@@ -1,6 +1,7 @@
 export default feed_obj = {
 	shouldUpdateByEdit: false,
 	shouldUpdateByComment: false,
+	edited_list: [],
 	edit_obj: {},
 	list: [],
 	deleted_obj: {},
@@ -8,4 +9,13 @@ export default feed_obj = {
 	mainHomeFeedList: [],
 	shouldUpdateUserProfile: false,
 	feed_writer: '',
+};
+
+export const pushEditedFeedList = res => {
+	const findIndex = feed_obj.edited_list.findIndex(e => e._id == res._id);
+	if (findIndex != -1) {
+		feed_obj.edited_list[findIndex] = res;
+	} else {
+		feed_obj.edited_list.push(res);
+	}
 };

--- a/src/navigation/header/FeedWriteHeader.js
+++ b/src/navigation/header/FeedWriteHeader.js
@@ -8,7 +8,7 @@ import Modal from 'Root/component/modal/Modal';
 import {RED10} from 'Root/config/color';
 import {createFeed, createMissing, createReport, editFeed, editMissingReport, getFeedDetailById} from 'Root/api/feedapi';
 import userGlobalObject from 'Root/config/userGlobalObject';
-import feed_obj from 'Root/config/feed_obj';
+import feed_obj, {pushEditedFeedList} from 'Root/config/feed_obj';
 import {useNavigation} from '@react-navigation/core';
 import {createThumbnail} from 'react-native-create-thumbnail';
 
@@ -63,7 +63,11 @@ export default FeedWriteHeader = ({route, options}) => {
 						let edited = {...route.params, feed_medias: result.msg.feed_medias, feed_thumbnail: result.msg.feed_thumbnail};
 						if (route.params && route.params.feed_type == 'report') {
 							edited.report_witness_location = result.msg?.report_witness_location;
+						} else if (route.params && route.params.feed_type == 'missing') {
+							console.log('result.msg?.missing_animal_date', result.msg?.missing_animal_date);
+							edited.missing_animal_date = result.msg?.missing_animal_date;
 						}
+						pushEditedFeedList(edited);
 						feed_obj.edit_obj = edited; //피드수정 => 수정한 리스트 아이템만 setData하기 위한 오브젝트
 						feed_obj.shouldUpdateByEdit = true;
 						navigation.goBack();
@@ -77,7 +81,7 @@ export default FeedWriteHeader = ({route, options}) => {
 						feed_obj.shouldUpdateUserProfile = true;
 						feed_obj.feed_writer = route.params.feed_avatar_id;
 						navigation.goBack();
-					} else
+					} else {
 						navigation.navigate('MainTab', {
 							screen: 'FEED',
 							params: {
@@ -85,6 +89,7 @@ export default FeedWriteHeader = ({route, options}) => {
 								params: {refreshing: true},
 							},
 						});
+					}
 				}
 			}
 		}, 200);
@@ -257,7 +262,7 @@ export default FeedWriteHeader = ({route, options}) => {
 					hashtag_keyword: route.params.hashtag_keyword?.map(v => v.substring(1)),
 				};
 
-				console.log('onEdit / FeedWrtieHeader', param);
+				// console.log('onEdit / FeedWrtieHeader', param);
 				if (param.feed_type == 'feed') {
 					if (param.feed_medias[0].is_video) {
 						createThumbnail({url: param.feed_medias[0].media_uri, timeStamp: 500})


### PR DESCRIPTION
*수정 사항: 
*수정 결과: 
*수정 파일:
1) src/component/molecules/media/FeedMedia.js 
-  두 개의 피드글을 연속적으로 수정할 경우, 피드리스트가 마지막 수정 내용만 갱신하던 현상 발견 => 전역관리변수에 수정된 항목은 List로 관리하도록 변경
-  각 자식 컴포넌트들도 수정List를 참조하여 갱신되도록 수정
-  불필요한 코드 제거

2) src/component/molecules/media/ProtectedThumbnail.js
-  두 개의 피드글을 연속적으로 수정할 경우, 피드리스트가 마지막 수정 내용만 갱신하던 현상 발견 => 전역관리변수에 수정된 항목은 List로 관리하도록 변경

3)  src/component/molecules/modal/OneButtonSelectModal.js
- "기타(직접 입력)"을 클릭하지 않고 한 번의 스크롤만으로 이동하여 확인을 누른 경우, 하단 입력 칸이 뜨지 않던 현상 수정

4) src/component/organism/feed/FeedContent.js
- 피드의 공개여부, 피드 내 사진의 태그리스트 수정 시 갱신이 되지 않던 현상 수정
- 기존의 위치가 있는 피드글을 수정할 경우 수정내용이 갱신되지 않고 기존의 위치만 출력되는 현상 수정
- 위치 추가, 임보 일기 옵션이 적용된 피드아이템에서 미트볼이 오른쪽으로 밀려서 안보이는 현상 수정
- 두 개의 피드글을 연속적으로 수정할 경우, 피드리스트가 마지막 수정 내용만 갱신하던 현상 발견 => 전역관리변수에 수정된 항목은 List로 관리하도록 변경

5) src/component/organism/feed/PhotoTagItem.js
-  피드 내 사진의 태그리스트 수정 시 갱신이 되지 않던 현상 수정

6) src/component/organism/listitem/MissingReportItem.js
- 두 개의 피드글을 연속적으로 수정할 경우, 피드리스트가 마지막 수정 내용만 갱신하던 현상 발견 => 전역관리변수에 수정된 항목은 List로 관리하도록 변경

7) src/component/templete/community/CommunityEdit.js
- 리뷰 수정 페이지에서 키보드가 올라온 상태에서 사진 추가 버튼을 눌러도 갤러리로 이동되지 않던 현상 수정

8) src/component/templete/feed/FeedCommentList.js
- 특정 피드의 댓글리스트 화면으로 가서 댓글을 작성하거나 댓글리스트를 받아 온 뒤 피드리스트 화면으로 복귀 => 사라졌던 피드의 최근 댓글 컴포넌트가 다시 출력되던 현상 발견
- 댓글의 전역관리 리스트에서 최근 댓글을 갱신하고 있던 코드 제거

9) src/component/templete/user/UserInfoSetting.js
- 유저 닉네임 수정 제한 글자를 validator 조건과 맞춤

10) src/navigation/header/FeedWriteHeader.js
- 실종게시물의 수정 후 피드리스트 화면에서 실종날짜 , 실종 장소가 빈 값으로 나오는 현상 수정