### PR TITLE
[상우] UI 오류사항 수정

### DIFF
--- a/src/component/organism/feed/FeedContent.js
+++ b/src/component/organism/feed/FeedContent.js
@@ -73,7 +73,7 @@ export default FeedContent = props => {
 				setCommentCount(feed_obj.list[findIndex].feed_comment_count);
 				setIsFavorite(feed_obj.list[findIndex].is_favorite);
 				const isEditedList = feed_obj.edited_list.map(v => v._id).includes(_id);
-				if (feed_obj.shouldUpdateByEdit && isEditedList) {
+				if (isEditedList) {
 					const edited_index = feed_obj.edited_list.findIndex(e => e._id == _id);
 					setData(feed_obj.edited_list[edited_index]);
 				}
@@ -533,7 +533,7 @@ export default FeedContent = props => {
 					!route.name.includes('TagMeFeedList') &&
 					(feed_type == 'report' || feed_type == 'missing') && (
 						<View style={[style.missingReportInfo]}>
-							<MissingReportInfo data={props.data} />
+							<MissingReportInfo data={data} isComment={props.isComment} />
 						</View>
 					)}
 				{props.showMedia ? (

--- a/src/component/organism/info/SocialInfoA.js
+++ b/src/component/organism/info/SocialInfoA.js
@@ -20,12 +20,21 @@ const SocialInfoA = props => {
 
 	const onClickFollower = () => {
 		if (props.data.user_type == 'pet') {
-			navigation.navigate('PetFollowerList', {userobject: props.data, title: props.data.user_follower_count});
-		} else navigation.navigate('SocialRelation', {userobject: props.data, initial: 'FollwerList'});
+			navigation.navigate({
+				key: props.data._id + 'PetFollowerList',
+				name: 'PetFollowerList',
+				params: {userobject: props.data, title: props.data.user_follower_count},
+			});
+		} else
+			navigation.navigate({
+				key: props.data._id + 'SocailRelation',
+				name: 'SocialRelation',
+				params: {userobject: props.data, initial: 'FollowerList'},
+			});
 	};
 
 	const onClickFollow = () => {
-		navigation.navigate('SocialRelation', {userobject: props.data, initial: 'FollowingList'});
+		navigation.navigate({key: props.data._id + 'SocailRelation', name: 'SocialRelation', params: {userobject: props.data, initial: 'FollowingList'}});
 	};
 
 	return (

--- a/src/component/organism/input/ReplyWriteBox.js
+++ b/src/component/organism/input/ReplyWriteBox.js
@@ -112,11 +112,11 @@ const ReplyWriteBox = React.forwardRef((props, ref) => {
 	} else if (props.isMessage) {
 		return (
 			<View style={[style.commentBox, {flexDirection: 'row', paddingTop: 20 * DP}]}>
-				<View style={[style.commentBox_top, {width: 550 * DP}, , {marginRight: 24 * DP}]}>
+				<View style={[style.commentBox_top, {width: 550 * DP}, {marginRight: 24 * DP}]}>
 					<TextInput
 						defaultValue={content == '' ? null : content}
 						value={content == '' ? null : content}
-						style={[style.replyTextInput]}
+						style={[style.replyTextInput, {width: 500 * DP, marginHorizontal: 20 * DP}]}
 						multiline={true}
 						placeholder={'메세지 입력..'}
 						placeholderTextColor="#000000"

--- a/src/component/organism/list/NoteList.js
+++ b/src/component/organism/list/NoteList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FlatList, ScrollView, Text, View, StyleSheet, SafeAreaView} from 'react-native';
+import {FlatList, ScrollView, Text, View, StyleSheet, SafeAreaView, RefreshControl} from 'react-native';
 import {accountHashList} from 'Organism/style_organism copy';
 import UserNote from '../listitem/UserNote';
 
@@ -9,15 +9,14 @@ import UserNote from '../listitem/UserNote';
  * @param {object} props.data - 쪽지 데이터
  * @param {void} props.onClickLabel - 쪽지 라벨 클릭
  * @param {void} props.onCheckBox - 선택 체크박스 클릭
+ * @param {void} props.refresh - 메시지 갱신
  * @param {boolean} props.checkBoxMode - 선택 삭제 모드 여부 (default= false)
  * @param {boolean} props.showFollowBtn - 선택 삭제 모드 여부 (default= false)
  */
 const NoteList = props => {
-	console.log('NoteList props', props.data);
 	const renderItem = ({item, index}) => {
-		console.log('item', item);
 		return (
-			<View style={[accountHashList.userAccount]}>
+			<View style={[style.userAccount]}>
 				<UserNote
 					data={item}
 					checkBoxMode={props.checkBoxMode}
@@ -28,12 +27,28 @@ const NoteList = props => {
 		);
 	};
 
+	const [refreshing, setRefreshing] = React.useState(false); //위로 스크롤 시도 => 리프레싱
+
+	const wait = timeout => {
+		return new Promise(resolve => setTimeout(resolve, timeout));
+	};
+
+	const onRefresh = () => {
+		setRefreshing(true);
+		wait(0).then(() => setRefreshing(false));
+	};
+
+	React.useEffect(() => {
+		refreshing ? props.refresh() : false;
+	}, [refreshing]);
+
 	return (
-		<View style={[styles.container]}>
+		<View style={[style.container]}>
 			<FlatList
-				// extraData={props.data}
+				extraData={props.data}
 				data={props.data}
-				// keyExtractor={item => item._id}
+				refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+				keyExtractor={item => item._id}
 				renderItem={renderItem}
 				showsVerticalScrollIndicator={false}
 				ListEmptyComponent={props.whenEmpty}
@@ -42,16 +57,17 @@ const NoteList = props => {
 	);
 };
 
-const styles = StyleSheet.create({
+const style = StyleSheet.create({
 	container: {
 		width: 750 * DP,
 		minHeight: 1322 * DP,
+		justifyContent: 'center',
 		alignItems: 'center',
 	},
-	userContainer: {
+	userAccount: {
 		width: 750 * DP,
-		// height: 94 * DP,
-		marginBottom: 40 * DP,
+		height: 94 * DP,
+		marginTop: 40 * DP,
 	},
 });
 
@@ -61,6 +77,7 @@ NoteList.defaultProps = {
 	onCheckBox: e => console.log(e),
 	checkBoxMode: false, // CheckBox 콘테이너 Show T/F
 	showFollowBtn: false,
+	refresh: () => {},
 };
 
 export default NoteList;

--- a/src/component/organism/list/NoteMessageList.js
+++ b/src/component/organism/list/NoteMessageList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FlatList, ScrollView, Text, View, StyleSheet, ActivityIndicator} from 'react-native';
+import {FlatList, ScrollView, Text, View, StyleSheet, ActivityIndicator, RefreshControl} from 'react-native';
 import OneMessage from 'Organism/listitem/OneMessage';
 import {styles} from 'Root/component/atom/image/imageStyle';
 
@@ -14,18 +14,29 @@ import {styles} from 'Root/component/atom/image/imageStyle';
  */
 const NoteMessageList = props => {
 	const flatlistRef = React.useRef();
+	const [refreshing, setRefreshing] = React.useState(false); //위로 스크롤 시도 => 리프레싱
 
 	React.useEffect(() => {
-		setTimeout(
-			() =>
-				flatlistRef.current?.scrollToIndex({
-					animated: true,
-					index: props.data.length - 1,
-					viewPosition: 0,
-				}),
-			1000,
-		);
+		fetchMsgList();
 	}, []);
+
+	const fetchMsgList = () => {
+		try {
+			if (props.data.length > 0) {
+				setTimeout(
+					() =>
+						flatlistRef.current?.scrollToIndex({
+							animated: true,
+							index: props.data.length - 1,
+							viewPosition: 0,
+						}),
+					1000,
+				);
+			}
+		} catch (err) {
+			console.log('err', err);
+		}
+	};
 
 	const renderItem = ({item, index}) => {
 		// console.log('item', item);
@@ -37,6 +48,19 @@ const NoteMessageList = props => {
 		);
 	};
 
+	const wait = timeout => {
+		return new Promise(resolve => setTimeout(resolve, timeout));
+	};
+
+	const onRefresh = () => {
+		setRefreshing(true);
+		wait(0).then(() => setRefreshing(false));
+	};
+
+	React.useEffect(() => {
+		refreshing ? fetchMsgList() : false;
+	}, [refreshing]);
+
 	return (
 		<View style={style.container}>
 			{/* <Text>쪽지 내용 리스트 나오는 화면</Text> */}
@@ -46,6 +70,7 @@ const NoteMessageList = props => {
 				renderItem={renderItem}
 				showsVerticalScrollIndicator={false}
 				ref={flatlistRef}
+				refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
 				onScrollToIndexFailed={info => {
 					const wait = new Promise(resolve => setTimeout(resolve, 500));
 					wait.then(() => {

--- a/src/component/organism/listitem/OneMessage.js
+++ b/src/component/organism/listitem/OneMessage.js
@@ -1,14 +1,11 @@
 import React from 'react';
-import {FlatList, ScrollView, Text, View, StyleSheet, Image, TouchableOpacity} from 'react-native';
-import {accountHashList} from 'Organism/style_organism copy';
-import UserNote from './UserNote';
+import {Text, View, StyleSheet, Image, TouchableOpacity} from 'react-native';
 import DP from 'Root/config/dp';
 import userGlobalObject from 'Root/config/userGlobalObject';
 import {txt} from 'Root/config/textstyle';
 import {APRI10, GRAY10, GRAY20, GRAY30, WHITE} from 'Root/config/color';
 import {ProfileDefaultImg} from 'Component/atom/icon';
 import {getTimeLapsed} from 'Root/util/dateutil';
-import {setMemoBoxWithReport} from 'Root/api/userapi';
 import Modal from 'Root/component/modal/Modal';
 import {REPORT_MENU} from 'Root/i18n/msg';
 import {createReport} from 'Root/api/report';
@@ -47,6 +44,7 @@ const OneMessage = props => {
 			'신고',
 		);
 	};
+
 	if (userGlobalObject.userInfo._id == data.memobox_send_id._id) {
 		return (
 			<View style={[{alignItems: 'center'}]}>
@@ -67,7 +65,7 @@ const OneMessage = props => {
 	else {
 		return (
 			<View style={[{alignItems: 'center'}]}>
-				<View style={styles.messageContainer}>
+				<View style={[styles.messageContainer]}>
 					<View style={styles.receivedMessageContainer}>
 						<View style={[{marginRight: 32 * DP}]}>
 							{data.memobox_send_id.user_profile_uri != undefined ? (
@@ -99,7 +97,7 @@ const OneMessage = props => {
 };
 const styles = StyleSheet.create({
 	messageContainer: {
-		width: 654 * DP,
+		width: 694 * DP,
 	},
 	sendMessageContainer: {
 		alignItems: 'flex-end',

--- a/src/component/organism/listitem/UserNote.js
+++ b/src/component/organism/listitem/UserNote.js
@@ -7,7 +7,7 @@ import {txt} from 'Root/config/textstyle';
 import DP from 'Root/config/dp';
 import {GRAY10, APRI10, BLACK} from 'Root/config/color';
 import {getTimeLapsed} from 'Root/util/dateutil';
-import {ProfileDefaultImg} from 'Root/component/atom/icon';
+import {Check42, Check50, Check64Filled, ProfileDefaultImg, Rect42_Border, Rect50_Border} from 'Root/component/atom/icon';
 /**
  * 쪽지 썸네일 객체
  * @param {object} props - Props Object
@@ -17,27 +17,28 @@ import {ProfileDefaultImg} from 'Root/component/atom/icon';
  * @param {boolean} props.checkBoxState - 선택 여부 (default = false)
  */
 const UserNote = props => {
-	// console.log('UserAccount item', props.data);
-	const data = props.data;
-	// console.log('time', data.memobox_date);
-	// console.log('getTime', getTimeLapsed(data.memobox_date));
-	// console.log('UserNote props', data);
+	const [data, setData] = React.useState(props.data);
+
+	React.useEffect(() => {
+		setData(props.data);
+	}, [props.data]);
 
 	return (
 		<View style={[styles.userNoteContainer]}>
 			{props.checkBoxMode ? (
-				<View style={[userAccount.checkBox]}>
-					<CheckBox
+				<View style={[userAccount.checkBox, {marginLeft: 10 * DP}]}>
+					{/* <CheckBox
 						state={props.data.checkBoxState}
 						onCheck={() => props.onCheckBox(props.data.type == 'HashTagObject' ? props.data.keyword : props.data.user_nickname)}
-					/>
+					/> */}
+					{data.checkBoxState ? <Check42 onPress={props.onCheckBox} /> : <Rect42_Border onPress={props.onCheckBox} />}
 				</View>
 			) : (
 				false
 			)}
 			{/* 메모 썸네일 객체 */}
 			<View style={[styles.userNoteContainer]}>
-				<TouchableOpacity onPress={() => props.onLabelClick(data)} disabled={props.checkBoxMode}>
+				<TouchableOpacity onPress={() => props.onLabelClick(data)}>
 					<View style={[styles.userNoteThumbnail]}>
 						{data.opponent_user_profile_uri != undefined ? (
 							<Image source={{uri: data.opponent_user_profile_uri}} style={[styles.img_round_94]} />
@@ -53,8 +54,8 @@ const UserNote = props => {
 								{/* {data.showStatus ? <Text style={[txt.noto22, {color: APRI10, alignSelf: 'center', paddingLeft: 10 * DP}]}> STATUS</Text> : null} */}
 							</View>
 							{data.memobox_contents ? (
-								<View style={[props.checkBoxMode ? {width: 450 * DP} : {width: 530 * DP}, {flexDirection: 'row'}]}>
-									<View style={[props.checkBoxMode ? {width: 328 * DP} : {width: 408 * DP}, {marginRight: 12 * DP}]}>
+								<View style={[props.checkBoxMode ? {width: 490 * DP} : {width: 568 * DP}, {flexDirection: 'row'}]}>
+									<View style={[props.checkBoxMode ? {width: 360 * DP} : {width: 444 * DP}, {marginRight: 12 * DP}]}>
 										<Text
 											style={[
 												txt.noto28,

--- a/src/component/templete/list/FollowerList.js
+++ b/src/component/templete/list/FollowerList.js
@@ -36,6 +36,10 @@ export default FollowerList = props => {
 	}, []);
 
 	React.useEffect(() => {
+		navigation.navigate(props.screen);
+	}, [props.screen]);
+
+	React.useEffect(() => {
 		setFollower(props.followers);
 		setLoading(false);
 	}, [props.followers]);

--- a/src/component/templete/pet/AssignPetInfoB.js
+++ b/src/component/templete/pet/AssignPetInfoB.js
@@ -87,14 +87,18 @@ export default AssignPetInfoB = props => {
 				Modal.close();
 				// console.log('success', success.msg);
 				// console.log('아바타', userGlobalObj.userInfo.user_avatar);
-				if (userGlobalObj.userInfo.user_avatar != undefined) {
-					userGlobalObj.userInfo.user_avatar = userGlobalObj.userInfo.user_avatar.push(success.msg);
+				try {
+					if (userGlobalObj.userInfo.user_avatar != undefined) {
+						userGlobalObj.userInfo.user_avatar = userGlobalObj.userInfo.user_avatar.push(success.msg);
+					}
+				} catch (err) {
+					console.log('err', err);
 				}
+
 				Modal.popNoBtn('반려동물 등록이 완료되었습니다.');
 				setTimeout(() => {
 					Modal.close();
 					console.log('반려 추가 등록 전 userGlobal', userGlobalObj.userInfo.hasOwnProperty('_id'));
-
 					// 일반유저가 MY탭에서 반려동물을 추가할 경우 계속 추가 등록이 가능하도록 네비게이션 초기화 처리
 					Modal.popTwoBtn(
 						'추가로 등록할 반려동물이 있나요?',

--- a/src/config/userGlobalObject.js
+++ b/src/config/userGlobalObject.js
@@ -13,7 +13,7 @@ export default userGlobalObj = {
 		user_type: '',
 		_id: '',
 		favorite_feedlist: [],
-		user_avatar: '',
+		user_avatar: [],
 	},
 	t: {
 		y: 0,

--- a/src/navigation/header/FeedWriteHeader.js
+++ b/src/navigation/header/FeedWriteHeader.js
@@ -48,11 +48,19 @@ export default FeedWriteHeader = ({route, options}) => {
 							{feedobject_id: param._id},
 							result => {
 								// navigation.navigate('FeedCommentList', {feedobject: result.msg});
+								let edited = {...route.params, feed_medias: result.msg.feed_medias, feed_thumbnail: result.msg.feed_thumbnail};
+								if (route.params && route.params.feed_type == 'report') {
+									edited.report_witness_location = result.msg?.report_witness_location; //제보 위치 타입 오류 방지를 위한 처리
+								} else if (route.params && route.params.feed_type == 'missing') {
+									edited.missing_animal_date = result.msg?.missing_animal_date; // 실종날짜 타입 오류 방지를 위한 처리
+								}
+								pushEditedFeedList(edited);
 								setTimeout(() => {
-									navigation.reset({
-										index: 1,
-										routes: [{name: 'MainTab'}, {name: 'FeedCommentList', params: {feedobject: result.msg}}],
-									});
+									navigation.goBack();
+									// navigation.reset({
+									// 	index: 1,
+									// 	routes: [{name: 'MainTab'}, {name: 'FeedCommentList', params: {feedobject: result.msg}}],
+									// });
 								}, 200);
 							},
 							err => {
@@ -62,10 +70,9 @@ export default FeedWriteHeader = ({route, options}) => {
 					} else {
 						let edited = {...route.params, feed_medias: result.msg.feed_medias, feed_thumbnail: result.msg.feed_thumbnail};
 						if (route.params && route.params.feed_type == 'report') {
-							edited.report_witness_location = result.msg?.report_witness_location;
+							edited.report_witness_location = result.msg?.report_witness_location; //제보 위치 타입 오류 방지를 위한 처리
 						} else if (route.params && route.params.feed_type == 'missing') {
-							console.log('result.msg?.missing_animal_date', result.msg?.missing_animal_date);
-							edited.missing_animal_date = result.msg?.missing_animal_date;
+							edited.missing_animal_date = result.msg?.missing_animal_date; // 실종날짜 타입 오류 방지를 위한 처리
 						}
 						pushEditedFeedList(edited);
 						feed_obj.edit_obj = edited; //피드수정 => 수정한 리스트 아이템만 setData하기 위한 오브젝트

--- a/src/navigation/route/main_tab/community_stack/CommunityMainStack.js
+++ b/src/navigation/route/main_tab/community_stack/CommunityMainStack.js
@@ -35,6 +35,7 @@ import SimpleWithMeatballHeader from 'Root/navigation/header/SimpleWithMeatballH
 import ReportDetail from 'Root/component/templete/missing/ReportDetail';
 import MissingAnimalDetail from 'Root/component/templete/missing/MissingAnimalDetail';
 import FeedCommentList from 'Root/component/templete/feed/FeedCommentList';
+import FeedListForHashTag from 'Root/component/templete/feed/FeedListForHashTag';
 
 const CommunityMainStackNavi = createStackNavigator();
 
@@ -192,7 +193,6 @@ export default CommunityMainStack = props => {
 				component={AddPhoto}
 				options={{header: props => <PhotoSelectHeader {...props} />, title: ''}}
 			/>
-
 			<CommunityMainStackNavi.Screen
 				name="EditShelterInfo"
 				component={EditShelterInfo}
@@ -212,6 +212,12 @@ export default CommunityMainStack = props => {
 				name="MissingAnimalDetail"
 				component={MissingAnimalDetail}
 				options={{header: props => <SimpleWithMeatballHeader {...props} />}}
+			/>
+			<CommunityMainStackNavi.Screen name="HashFeedList" component={FeedList} options={{header: props => <SimpleHeader {...props} />, title: ''}} />
+			<CommunityMainStackNavi.Screen
+				name="FeedListForHashTag"
+				component={FeedListForHashTag}
+				options={{header: props => <SimpleHeader {...props} />, title: '#반려동물'}}
 			/>
 		</CommunityMainStackNavi.Navigator>
 	);

--- a/src/navigation/route/main_tab/protection_stack/ProtectionStackNavigation.js
+++ b/src/navigation/route/main_tab/protection_stack/ProtectionStackNavigation.js
@@ -63,7 +63,7 @@ export default ProtectionStackNavigation = props => {
 				options={{header: props => <InputAndSearchHeader {...props} type={'social'} />}}
 			/>
 			<ProtectionStack.Screen name="UserFeedList" component={FeedList} options={{header: props => <SimpleHeader {...props} />}} />
-			<ProtectionStack.Screen name="HashFeedList" component={FeedList} />
+			<ProtectionStack.Screen name="HashFeedList" component={FeedList} options={{header: props => <SimpleHeader {...props} />}} />
 			<ProtectionStack.Screen name="ProtectAnimalFeedList" component={FeedList} />
 			<ProtectionStack.Screen name="UserTagFeedList" component={FeedList} options={{header: props => <SimpleHeader {...props} />, title: '프로필'}} />
 			<ProtectionStack.Screen

--- a/src/navigation/route/main_tab/protection_stack/socialRelation_tab/SocialRelationTopTabNavigation.js
+++ b/src/navigation/route/main_tab/protection_stack/socialRelation_tab/SocialRelationTopTabNavigation.js
@@ -2,13 +2,13 @@ import React from 'react';
 import {StyleSheet, Dimensions} from 'react-native';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 import FollowerList from 'Templete/list/FollowerList';
-import RecommendedAccountList from 'Templete/list/RecommendedAccountList';
 import DP from 'Root/config/dp';
 import {APRI10, BLACK, GRAY10, GRAY40, WHITE} from 'Root/config/color';
 import {count_to_K} from 'Root/util/stringutil';
 import {getFollowers, getFollows, getUserProfile} from 'Root/api/userapi';
 import {useNavigation} from '@react-navigation/core';
 import searchContext from 'Root/config/searchContext';
+import Loading from 'Root/component/molecules/modal/Loading';
 
 const SocialRelationTab = createMaterialTopTabNavigator();
 
@@ -22,7 +22,6 @@ export default SocialRelationTopTabNavigation = props => {
 	const [loading, setLoading] = React.useState(true);
 	const params = props.route.params;
 	const initial = params.initial != undefined ? params.initial : 'FollowerList';
-	// console.log('type', data.user_type);
 
 	React.useEffect(() => {
 		const unsubscribe = navigation.addListener('blur', () => {
@@ -33,22 +32,25 @@ export default SocialRelationTopTabNavigation = props => {
 
 	//헤더 타이틀 설정 작업 및 유저 오브젝트 할당
 	React.useEffect(() => {
-		navigation.setOptions({title: params.userobject.user_nickname});
 		fetchData();
-	}, [params]);
+	}, []);
 
 	React.useEffect(() => {
 		//입력마다 api 접속하는 것이 아닌 타이핑 이후 500ms 주어 타이핑이 종료되었을 때 검색을 실시하도록 timeOut 설정
-		setTimeout(() => {
-			fetchFollowerData();
-		}, 300);
+		if (data != 'false') {
+			setTimeout(() => {
+				fetchFollowerData();
+			}, 300);
+		}
 	}, [followerInput]);
 
 	React.useEffect(() => {
 		//입력마다 api 접속하는 것이 아닌 타이핑 이후 500ms 주어 타이핑이 종료되었을 때 검색을 실시하도록 timeOut 설정
-		setTimeout(() => {
-			fetchFollowData();
-		}, 300);
+		if (data != 'false') {
+			setTimeout(() => {
+				fetchFollowData();
+			}, 300);
+		}
 	}, [followInput]);
 
 	const fetchData = async () => {
@@ -153,46 +155,69 @@ export default SocialRelationTopTabNavigation = props => {
 		setFollowInput(text);
 	};
 
-	return (
-		<SocialRelationTab.Navigator
-			initialRouteName={initial}
-			screenOptions={{
-				tabBarItemStyle: {height: 78 * DP},
-				tabBarIndicatorStyle: {backgroundColor: params.userobject.user_type == 'pet' ? WHITE : BLACK, height: 6 * DP},
-				tabBarLabelStyle: [styles.tabbarLabelStyle],
-				tabBarInactiveTintColor: GRAY10,
-				tabBarActiveTintColor: BLACK,
-				tabBarStyle: {
-					borderBottomWidth: 2 * DP,
-					borderTopColor: GRAY40,
-					borderBottomColor: GRAY40,
-					elevation: 0,
-					// height: params.userobject.user_type == 'pet' ? 0 : 78 * DP,
-				},
-			}}
-			initialLayout={{width: Dimensions.get('window').width}}
-			optimizationsEnabled={true}>
-			{/* <SocialRelationTab.Screen name="LinkedAccountList" component={LinkedAccountList} initialParams={{userobject: data}} /> */}
-			<SocialRelationTab.Screen
-				name="FollowerList"
-				initialParams={{userobject: data}}
-				options={{tabBarLabel: count_to_K(followers.length) + ' ' + '팔로워'}}>
-				{props => (
-					<FollowerList {...props} followers={followers} resetProfileInfo={fetchData} onChangeSearchInput={onChangeFollower} loading={loading} />
-				)}
-			</SocialRelationTab.Screen>
-			{params.userobject.user_type != 'pet' ? (
+	if (data == 'false') {
+		return (
+			<>
+				<Loading isModal={false} />
+			</>
+		);
+	} else
+		return (
+			<SocialRelationTab.Navigator
+				initialRouteName={initial}
+				screenOptions={{
+					tabBarItemStyle: {height: 78 * DP},
+					tabBarIndicatorStyle: {backgroundColor: params.userobject.user_type == 'pet' ? WHITE : BLACK, height: 6 * DP},
+					tabBarLabelStyle: [styles.tabbarLabelStyle],
+					tabBarInactiveTintColor: GRAY10,
+					tabBarActiveTintColor: BLACK,
+					tabBarStyle: {
+						borderBottomWidth: 2 * DP,
+						borderTopColor: GRAY40,
+						borderBottomColor: GRAY40,
+						elevation: 0,
+						// height: params.userobject.user_type == 'pet' ? 0 : 78 * DP,
+					},
+				}}
+				initialLayout={{width: Dimensions.get('window').width}}
+				optimizationsEnabled={true}>
+				{/* <SocialRelationTab.Screen name="LinkedAccountList" component={LinkedAccountList} initialParams={{userobject: data}} /> */}
 				<SocialRelationTab.Screen
-					name="FollowingList"
+					name="FollowerList"
 					initialParams={{userobject: data}}
-					options={{tabBarLabel: count_to_K(follows.length) + ' ' + '팔로잉'}}>
-					{props => <FollowerList {...props} follows={follows} resetProfileInfo={fetchData} onChangeSearchInput={onChangeFollow} loading={loading} />}
+					options={{tabBarLabel: count_to_K(followers.length) + ' ' + '팔로워'}}>
+					{props => (
+						<FollowerList
+							{...props}
+							followers={followers}
+							resetProfileInfo={fetchData}
+							onChangeSearchInput={onChangeFollower}
+							loading={loading}
+							screen={params.initial}
+						/>
+					)}
 				</SocialRelationTab.Screen>
-			) : (
-				<></>
-			)}
+				{params.userobject.user_type != 'pet' ? (
+					<SocialRelationTab.Screen
+						name="FollowingList"
+						initialParams={{userobject: data}}
+						options={{tabBarLabel: count_to_K(follows.length) + ' ' + '팔로잉'}}>
+						{props => (
+							<FollowerList
+								{...props}
+								follows={follows}
+								resetProfileInfo={fetchData}
+								onChangeSearchInput={onChangeFollow}
+								loading={loading}
+								screen={params.initial}
+							/>
+						)}
+					</SocialRelationTab.Screen>
+				) : (
+					<></>
+				)}
 
-			{/* <SocialRelationTab.Screen
+				{/* <SocialRelationTab.Screen
 				name="RecommendedAccountList"
 				options={{
 					tabBarLabel: '추천',
@@ -200,8 +225,8 @@ export default SocialRelationTopTabNavigation = props => {
 				component={RecommendedAccountList}
 				initialParams={{userobject: data}}
 			/> */}
-		</SocialRelationTab.Navigator>
-	);
+			</SocialRelationTab.Navigator>
+		);
 };
 
 const styles = StyleSheet.create({

--- a/src/navigation/route/search_tab/SearchTabNavigation.js
+++ b/src/navigation/route/search_tab/SearchTabNavigation.js
@@ -69,7 +69,6 @@ export default SearchTabNavigation = props => {
 	async function fetchData() {
 		setLoading(true);
 		if (searchContext.searchInfo.searchInput && searchContext.searchInfo.searchInput.length > 1) {
-			console.log('fetch?');
 			const user = await getUserList(); //계정 검색
 			const hash = await getHashList(); //태그 검색
 			const comm = await getCommunityList(); //커뮤니티 검색


### PR DESCRIPTION
*수정 사항: 
*수정 결과: 
*수정 파일: 
1) src/component/organism/feed/FeedContent.js
    src/component/organism/info/MissingReportInfo.js
- 피드 수정 리스트가 정상적으로 적용되지 않던 현상 수정
- 제보게시글의 댓글리스트 화면 상단에서 피드 내용이 두 번 출력되던 현상 발견 => FeedCommentList 페이지에서는 '제보 내용'란이 출력되지 않도록 적용 
- 실종/제보 게시글의 수정시 갱신되도록 적용
- 수정 후 특정 필드의 타입오류 발생 => 타입에 따른 분기처리로 필드 출력 유지되도록 변경

2) src/component/organism/info/SocialInfoA.js
     src/component/templete/list/FollowerList.js
- 특정 계정의 팔로우 리스트 화면으로 이동 => 아무 계정 클릭 => 팔로우 리스트 화면으로 다시 이동 => 이전 팔로우 리스트 데이터가 남아 있는 상태로 페이지가 갱신
- key 값이 고유하지 않은 'SocialRelation'으로 지속적으로 navigate하면서 발생하던 문제
- 같은 계정의 팔로우 리스트화면으로 이동하는 것이 아니라면 새로운 스크린 인스턴스를 만들도록 변경
- 같은 계정의 팔로우 리스트 화면으로 이동하지만 탭이 다를 경우(예를 들어 처음에는 '팔로우' 클릭 => 두 번째로는 '팔로잉' 클릭) 클릭된 탭으로 이동하도록 변경

3) src/component/organism/input/ReplyWriteBox.js
- 쪽지 상세페이지에서 내용이 길어질 경우 텍스트가 입력 영역을 침범하는 현상 발견
- ReplyWriteBox에서 style을 공유하고 있었고 해당 부분이 변경되면서 적용되던 문제
- 결합도 문제로 쪽지 상세에서는 ReplyWriteBox 컴포넌트를 굳이 사용해야 할까 의문 (공통되는 기능이 내용 입력 밖에 없는 상태)

4) src/component/organism/list/NoteList.js
     src/component/templete/user/ReceivedMessage.js
     src/component/organism/listitem/OneMessage.js
     src/component/organism/listitem/UserNote.js
- 쪽지함 상단의 '선택하기' 버튼 클릭 후 새로고침 기능 시 checkBox가 전부 '선택'상태로 변하던 현상 발견 
   => 쪽지 리스트 갱신 발생 시 '선택'상태가 상시 초기화 되도록 변경
- 쪽지함에서 2개 이상의 쪽지 삭제 시도 시 중복된 쪽지리스트가 덧씌워지는 현상 발견 
  => 현재  삭제하는 쪽지의 개수만큼 삭제 api에 접속(5개를 삭제한다면 5번의 삭제 api 접속) => 추후 한 번의 api로 리스트를 삭제하는 방식 도 
        입 필요 => 현재는 모든 삭제작업이 끝나고 단 한 번 쪽지리스트를 갱신하도록 변경
- 쪽지리스트 개수 많을 경우, 최하단 아이템으로 스크롤이 되지 않는 현상 수정
- 선택하기를 누른 뒤, 체크박스가 아닌 쪽지 아이템을 클릭해도 토글이 되도록 변경
- 쪽지 FlatList에 refreshing 기능 적용
- 쪽지 FlatList 최적화 코드 적용
- 쪽지의 너비가  654 => 694

5) src/component/templete/pet/AssignPetInfoB.js
     src/config/userGlobalObject.js
- 최초 회원가입 후 반려동물 등록시 마지막 단계에서 '다음' 버튼이 작동하지 않던 현상 발견
- 전역 변수에 추가된 반려동물을 갱신하는 과정에서 발생하던 타입 오류로 판정

6)  src/component/templete/list/AlarmList.js
- 이미 삭제한 쪽지에 대한 알림 클릭시 이동이 사전차단되도록 수정
- 이미 삭제된 보호요청에 대한 댓글알람 이동 시도시 사전차단되도록 수정

7) src/navigation/header/FeedWriteHeader.js
- 피드를 해당 피드의 댓글리스트 화면에서 수정=> 완료 후 수정 내용이 리스트 화면에서 갱신이 안되던 현상 수정
- 수정의 전역관리 리스트 코드 추가
- 실종 및 제보글의 수정 발생 시 타입오류가 일어나지 않도록 분기 처리 추가
- 어떤 탭이던 댓글리스트화면에서 수정 발생 시 메인화면(피드 탭의 메인리스트 화면)으로 가지던 현상 수정 

8) src/navigation/route/main_tab/community_stack/CommunityMainStack.js
     src/navigation/route/main_tab/protection_stack/ProtectionStackNavigation.js
- 특정탭들에서 해쉬태그 클릭시 헤더의 스타일이 적용되지 않은 채로 출력되던 현상 수정

9) src/navigation/route/main_tab/protection_stack/socialRelation_tab/SocialRelationTopTabNavigation.js
- 팔로워 리스트 화면에 로딩 화면 적용
- 불필요한 api 중복 접속 해소 코드 추가
- 팔로잉, 팔로워 탭 간의 이동이 스크린마다 가능하도록 FollowerList 컴포넌트에 대한 screen props 추가





