### PR TITLE
[재현] 인증 실패시 navigation 수정, FeedCommentList 꺼지던 오류 수정

### DIFF
--- a/src/component/organism/form/PhoneNumVerification.js
+++ b/src/component/organism/form/PhoneNumVerification.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {Text, View, StyleSheet, TouchableOpacity} from 'react-native';
 import {APRI10, GRAY10, GREEN, WHITE} from 'Root/config/color';
 import {txt} from 'Root/config/textstyle';
@@ -55,6 +55,7 @@ export default PhoneNumVerification = props => {
 	// 		props.requestVerification();
 	// 	}
 	// };
+
 	const onNameInputChange = text => {
 		setUserName(text);
 		props.onNameInputChange(text);
@@ -166,25 +167,18 @@ export default PhoneNumVerification = props => {
 					verified={props?.phoneVerified}
 				/>
 			</View>
-			<View style={[{flexDirection: 'row'}, {marginTop: 14 * DP}]}>
+			{/* <View style={[{flexDirection: 'row'}, {marginTop: 14 * DP}]}>
 				{props.failed ? (
-					<View style={[{position: 'absolute', right: -10, bottom: -15}]}>
+					<View style={[{position: 'absolute', right: 0, bottom: -15}]}>
 						<TouchableOpacity onPress={props.requestVerification}>
 							<Text style={[txt.noto28b, {color: APRI10}, {textDecorationLine: 'underline'}]}>재인증</Text>
 						</TouchableOpacity>
 					</View>
 				) : (
-					// <Text></Text>
 					<Text style={[txt.noto24, {color: GRAY10}, {marginLeft: 200 * DP}]}>입력한 내용이 인증창이 뜰 시 자동 입력됩니다.</Text>
 				)}
-				{/* {props.phoneVerified ? (
-					<View style={[{position: 'absolute', right: 50, bottom: 0}]}>
-						<Text style={[txt.noto28b, {color: APRI10}]}>인증완료</Text>
-					</View>
-				) : (
-					<Text></Text>
-				)} */}
-			</View>
+			
+			</View> */}
 
 			{/* {validPhone ? (
 				<Text style={[txt.noto26, phoneNumVerification.phoneNumValidPassedText, {color: GREEN}]}>휴대전화번호 양식과 일치합니다. </Text>

--- a/src/component/templete/feed/FeedCommentList.js
+++ b/src/component/templete/feed/FeedCommentList.js
@@ -41,11 +41,13 @@ export default FeedCommentList = props => {
 
 	React.useEffect(() => {
 		fetchData();
-		params.showKeyboard
-			? setTimeout(() => {
-					input.current.focus();
-			  }, 200)
-			: false;
+		if (userGlobalObject.userInfo._id != '') {
+			params.showKeyboard
+				? setTimeout(() => {
+						input.current.focus();
+				  }, 200)
+				: false;
+		}
 
 		// 실종,제보에서 댓글 수정 클릭시 수정데이터 덮어씌우고 스크롤 수행
 		if (params.edit && editFromDetailRef) {

--- a/src/component/templete/login/Certification.js
+++ b/src/component/templete/login/Certification.js
@@ -53,11 +53,15 @@ export default function Certification({route}) {
 						data={params}
 						loading={<Loading />}
 						callback={response => {
-							console.log('reponse', response);
-							(response.imp_success || response.success) &&
-								// navigation.navigate(route.params.navigationName, {response: response, user_data: route.params?.user_data});
+							console.log('핸드폰 인증 response', response);
+							// (response.imp_success || response.success) &&
+							if (response.success == 'true') {
+								console.log('인증성공');
 								navigation.replace(route.params.navigationName, {response: response, user_data: route.params?.user_data});
-							// navigation.reset({routes: [{name: route.params.navigationName}]});
+							} else {
+								console.log('인증 실패');
+								navigation.goBack();
+							}
 						}}
 					/>
 				</SafeAreaView>


### PR DESCRIPTION
*수정 사항: 인증 실패시 navigation.goBack()을 사용해서 분기처리했습니다. / FeedCommentList에서 UserObject.userInfo._id ='' 일때 ReplyWirteBox를 랜더하지 않기때문에 !=' ' 일때문 input.current.focus() 하도록 수정했습니다.

*수정 파일: 
PhoneNumVerification - 인증실패 했을시의 UI 수정 
FeedCommentList - ref 없을때 분기처리 
Certification - 인증 실패시 분기처리 
