### PR TITLE
[상우] UI 오류 사항 수정

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,6 @@
 import React, {useEffect} from 'react';
-import {Platform,View,Text,TouchableOpacity} from 'react-native';
-import { txt } from 'Root/config/textstyle';
+import {Platform, View, Text, TouchableOpacity, LogBox} from 'react-native';
+import {txt} from 'Root/config/textstyle';
 import RootStackNavigation from 'Navigation/route/RootStackNavigation';
 import codePush from 'react-native-code-push';
 import appConfig, {DEV, RELEASE, STAGING} from 'Root/config/appConfig';
@@ -10,8 +10,11 @@ import {init, captureMessage} from '@sentry/browser';
 import {RewriteFrames as RewriteFramesIntegration} from '@sentry/integrations';
 import Raven from 'raven-js';
 import ErrorBoundary from 'react-native-error-boundary';
+import {SafeAreaProvider} from 'react-native-safe-area-context';
+
 // require('raven-js/plugins/react-native')(Raven)
 // import Raven from 'raven-js/plugins/react-native';
+LogBox.ignoreLogs(['Sending']);
 const NoRaven = false;
 const RELEASE_ID = appConfig.sentryReleaseID;
 const PUBLIC_DSN = appConfig.mode == DEV ? appConfig.sentryDsnStaging : appConfig.sentryDsnRelease;
@@ -21,7 +24,7 @@ const integrations =
 		: new RewriteFramesIntegration({
 				prefix: '',
 		  });
-(function sentryinit(){
+(function sentryinit() {
 	Sentry.init({
 		dsn: PUBLIC_DSN,
 		release: RELEASE_ID,
@@ -33,8 +36,8 @@ const integrations =
 		release: RELEASE_ID,
 		integrations: [integrations],
 	});
-	!NoRaven&&Raven.config(PUBLIC_DSN, {release: RELEASE_ID}).install();
-})()
+	!NoRaven && Raven.config(PUBLIC_DSN, {release: RELEASE_ID}).install();
+})();
 const codePushOptions = {
 	checkFrequency: codePush.CheckFrequency.ON_APP_RESUME,
 	// 언제 업데이트를 체크하고 반영할지를 정한다.
@@ -64,9 +67,9 @@ const consoleOld = console;
 		}
 	});
 })();
-const ErrorPage = (props) => {
+const ErrorPage = props => {
 	return (
-		<View style={{flex:1,backgroundColor:'red',justifyContent:'center',alignItems:'center'}}>
+		<View style={{flex: 1, backgroundColor: 'red', justifyContent: 'center', alignItems: 'center'}}>
 			<Text style={txt.noto30b}>에러가 발생했습니다.</Text>
 			<TouchableOpacity style={{width: 300, height: 300, backgroundColor: 'yellow'}} onPress={() => codePush.restartApp()}>
 				<Text style={txt.noto24b}>앱을 재시작합니다. 노란 박스를 눌러주세요</Text>
@@ -91,14 +94,14 @@ const App = () => {
 	// 	// <Route/>
 	// );
 
-	
-
 	return (
-		<Sentry.ErrorBoundary fallback={props=><ErrorPage {...props}/>}>
-			<RootStackNavigation />
-		</Sentry.ErrorBoundary>
+		<SafeAreaProvider>
+			<Sentry.ErrorBoundary fallback={props => <ErrorPage {...props} />}>
+				<RootStackNavigation />
+			</Sentry.ErrorBoundary>
+		</SafeAreaProvider>
 	);
 };
 // export default Sentry.wrap(codePush(codePushOptions)(App));
-export default (codePush(codePushOptions)(Sentry.wrap(App)));
-// export default App
+// export default (codePush(codePushOptions)(Sentry.wrap(App)));
+export default App;

--- a/src/component/molecules/modal/AvatarSelectFromWriteModal.js
+++ b/src/component/molecules/modal/AvatarSelectFromWriteModal.js
@@ -10,6 +10,7 @@ import {styles} from 'Root/component/atom/image/imageStyle';
 import {Paw30_APRI10, Paw30_Mixed, Paw30_YELL20, ProfileDefaultImg, Triangle, Write94} from 'Atom/icon';
 import FastImage from 'react-native-fast-image';
 import {NETWORK_ERROR} from 'Root/i18n/msg';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 /**
  * 글쓰기 선택 후 아바타 동물을 선택하는 모달창
@@ -23,6 +24,8 @@ const AvatarSelectFromWriteModal = props => {
 	const [items, setItems] = React.useState('');
 	const scrollViewRef = React.useRef();
 	const [scrollIndex, setScrollIndex] = React.useState(0); //현재 스크롤 페이지
+	const insets = useSafeAreaInsets();
+	console.log('ind', insets);
 
 	//첫 클릭 시 사용자의 반려동물 리스트를 받아서 user_avatar 전역변수에 저장
 	React.useEffect(() => {
@@ -156,7 +159,13 @@ const AvatarSelectFromWriteModal = props => {
 					onPress={closeModal}
 					// android 180 ios 235 였음
 					// style={[style.popUpWindow, {marginBottom: Platform.OS == 'android' ? 180 * DP : 275 * DP}, {backgroundColor: 'yellow'}]}>
-					style={[style.popUpWindow, {marginBottom: Platform.OS == 'android' ? 145 * DP : 240 * DP}]}>
+					style={[
+						style.popUpWindow,
+						{
+							// marginBottom: Platform.OS == 'android' ? 145 * DP : 240 * DP
+							bottom: 140 * DP + insets.bottom,
+						},
+					]}>
 					{scrollUp()}
 					<View style={[style.avatarList, {}]}>
 						<FlatList
@@ -193,7 +202,7 @@ const AvatarSelectFromWriteModal = props => {
 							</TouchableOpacity>
 						)}
 					</View>
-					<View style={[style.writeBtn, {bottom: Platform.OS == 'android' ? 20 * DP : -10 * DP}]}>
+					<View style={[style.writeBtn, {}]}>
 						<Write94 />
 					</View>
 				</TouchableOpacity>
@@ -235,11 +244,8 @@ const style = StyleSheet.create({
 		position: 'absolute',
 	},
 	popUpWindow: {
-		// width: 488 * DP,
-		marginBottom: 235 * DP,
-
-		marginRight: 35 * DP,
-		// backgroundColor: 'white',
+		position: 'absolute',
+		right: 30 * DP,
 	},
 	avatarList: {
 		maxHeight: 114 * 4 * DP,
@@ -281,16 +287,10 @@ const style = StyleSheet.create({
 		// backgroundColor: 'red',
 	},
 	writeBtn: {
-		// height: 94 * DP,
-		// width: 94 * DP,
 		alignSelf: 'flex-end',
 		justifyContent: 'center',
 		alignItems: 'center',
-		// backgroundColor: '#ff9888',
-		// backgroundColor: 'red',
 		borderRadius: 35 * DP,
-		marginBottom: -5 * DP,
-		right: -3 * DP,
 	},
 });
 

--- a/src/component/molecules/modal/OneButtonSelectModal.js
+++ b/src/component/molecules/modal/OneButtonSelectModal.js
@@ -116,6 +116,8 @@ const OneButtonSelectModal = props => {
 	//하단 드롭다운에서 완료 버튼 클릭
 	const onSelect = () => {
 		setSelectOpen(false);
+		setConfirmIndex(selectedItem);
+		setSelectedItem(selectedItem);
 		setConfirmedSelect(data[selectedItem - 2]);
 	};
 

--- a/src/component/molecules/modal/UrgentBtnModal.js
+++ b/src/component/molecules/modal/UrgentBtnModal.js
@@ -5,6 +5,7 @@ import DP from 'Root/config/dp';
 import Modal from 'Component/modal/Modal';
 import {txt} from 'Root/config/textstyle';
 import {Urgent_Write2} from 'Atom/icon';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 /**
  * 긴급 게시 버튼 출력 모달
@@ -14,7 +15,9 @@ import {Urgent_Write2} from 'Atom/icon';
  * @param {Object} props.layout - 액션 버튼 실제 위치 정보
  */
 const UrgentBtnModal = ({onReport, onMissing, layout, setPressed}) => {
-	console.log('layout', layout);
+	const insets = useSafeAreaInsets();
+	// console.log('ind', insets);
+
 	const moveToMissingForm = () => {
 		console.log('moveToMissingForm');
 		onMissing();
@@ -31,10 +34,7 @@ const UrgentBtnModal = ({onReport, onMissing, layout, setPressed}) => {
 
 	return (
 		<TouchableOpacity onPress={() => Modal.close()} activeOpacity={1} style={style.background}>
-			<TouchableOpacity
-				activeOpacity={1}
-				onPress={() => Modal.close()}
-				style={[style.popUpWindow, {bottom: Platform.OS == 'android' ? layout.y - 104 * DP : layout.y - 40 * DP}]}>
+			<TouchableOpacity activeOpacity={1} onPress={() => Modal.close()} style={[style.popUpWindow, {}]}>
 				<View style={[{marginTop: 0 * DP}]}>
 					<TouchableOpacity onPress={moveToMissingForm} activeOpacity={0.4} style={[style.urgentBtnItemContainer]}>
 						<Text style={[txt.noto32, {color: WHITE}]}>실종</Text>
@@ -42,13 +42,13 @@ const UrgentBtnModal = ({onReport, onMissing, layout, setPressed}) => {
 					<TouchableOpacity onPress={moveToReportForm} activeOpacity={0.4} style={[style.urgentBtnItemContainer]}>
 						<Text style={[txt.noto32, {color: WHITE}]}>제보</Text>
 					</TouchableOpacity>
-					<View style={[style.urgentActionButton]}>
-						<TouchableOpacity onPress={onPressShowActionButton}>
-							<Urgent_Write2 />
-						</TouchableOpacity>
-					</View>
 				</View>
 			</TouchableOpacity>
+			<View style={[style.urgentActionButton, {height: Platform.OS == 'android' ? 186 * DP : 186 * DP + insets.bottom}]}>
+				<TouchableOpacity onPress={onPressShowActionButton}>
+					<Urgent_Write2 />
+				</TouchableOpacity>
+			</View>
 		</TouchableOpacity>
 	);
 };
@@ -73,19 +73,9 @@ const style = StyleSheet.create({
 		position: 'absolute',
 	},
 	popUpWindow: {
-		// width: 110 * DP,
-		// height: 110 * DP,
-		// position: 'absolute',
-		// marginBottom: 235 * DP,
-		// marginRight: 60 * DP,
-		// justifyContent: 'center',
-		// backgroundColor: 'white',
-		// opacity: 0.9,
 		width: 158 * DP,
-		height: 332 * DP,
-		position: 'absolute',
 		right: 30 * DP,
-		// bottom: 40 * DP,
+		bottom: 40 * DP,
 		justifyContent: 'flex-end',
 	},
 	urgentBtnItemContainer: {
@@ -99,22 +89,11 @@ const style = StyleSheet.create({
 	},
 	urgentActionButton: {
 		width: 98 * DP,
-		height: 86 * DP,
+		height: 186 * DP,
 		alignSelf: 'flex-end',
-		// backgroundColor: 'white',
-		shadowColor: '#000000',
-		shadowOpacity: 0.5,
 		borderRadius: 40 * DP,
-		shadowOffset: {
-			width: 2,
-			height: 2,
-		},
-		shadowRadius: 4.65,
-		// shadowOffset: {
-		// 	width: 2 * DP,
-		// 	height: 1 * DP,
-		// },
-		elevation: 4,
+		right: 30 * DP,
+		bottom: 40 * DP,
 	},
 });
 

--- a/src/component/organism/list/NoteMessageList.js
+++ b/src/component/organism/list/NoteMessageList.js
@@ -17,10 +17,10 @@ const NoteMessageList = props => {
 	const [refreshing, setRefreshing] = React.useState(false); //위로 스크롤 시도 => 리프레싱
 
 	React.useEffect(() => {
-		fetchMsgList();
-	}, []);
+		scrollToMsg();
+	}, [props.data]);
 
-	const fetchMsgList = () => {
+	const scrollToMsg = () => {
 		try {
 			if (props.data.length > 0) {
 				setTimeout(
@@ -30,7 +30,7 @@ const NoteMessageList = props => {
 							index: props.data.length - 1,
 							viewPosition: 0,
 						}),
-					1000,
+					100,
 				);
 			}
 		} catch (err) {
@@ -58,7 +58,7 @@ const NoteMessageList = props => {
 	};
 
 	React.useEffect(() => {
-		refreshing ? fetchMsgList() : false;
+		refreshing ? scrollToMsg() : false;
 	}, [refreshing]);
 
 	return (

--- a/src/component/templete/community/ArticleDetail.js
+++ b/src/component/templete/community/ArticleDetail.js
@@ -92,7 +92,7 @@ export default ArticleDetail = props => {
 				community_object_id: props.route.params.community_object._id,
 			},
 			result => {
-				console.log('ArticleDetail / getCommunityByObjectId / Result', result.status);
+				// console.log('ArticleDetail / getCommunityByObjectId / Result', result.msg);
 				setData(result.msg);
 				switch (result.msg.community_free_type) {
 					case 'talk':
@@ -180,6 +180,7 @@ export default ArticleDetail = props => {
 							res[i].isDeleted = false;
 						});
 					}
+					data != 'false' ? updateCommentsLength(res) : false;
 					res.push(dummyForBox);
 					setComments(res);
 					if (props.route.params.comment) {
@@ -258,6 +259,7 @@ export default ArticleDetail = props => {
 								comments => {
 									!parentComment && setComments([]); //댓글목록 초기화
 									let res = comments.msg.filter(e => !e.comment_is_delete || e.children_count != 0);
+									updateCommentsLength(res);
 									let dummyForBox = res[res.length - 1];
 									if (editData.parent != undefined && editData.children_count == 0) {
 										res.map((v, i) => {
@@ -322,6 +324,7 @@ export default ArticleDetail = props => {
 								comments => {
 									!parentComment && setComments([]); //댓글목록 초기화
 									let res = comments.msg.filter(e => !e.comment_is_delete || e.children_count != 0);
+									updateCommentsLength(res);
 									let dummyForBox = res[res.length - 1];
 									res.push(dummyForBox);
 									setComments(res);
@@ -360,6 +363,18 @@ export default ArticleDetail = props => {
 				Modal.close();
 			}
 		}
+	};
+
+	const updateCommentsLength = res => {
+		let commets_length = 0;
+		res.map((v, i) => {
+			commets_length = commets_length + v.children_count;
+			if (v.comment_is_delete) {
+				commets_length--;
+			}
+		});
+		commets_length = commets_length + res.length;
+		data != 'false' ? setData({...data, community_comment_count: commets_length}) : false;
 	};
 
 	const [isReplyFocused, setReplyFocus] = React.useState(false);
@@ -644,7 +659,7 @@ export default ArticleDetail = props => {
 					</TouchableOpacity>
 					{comments && comments.length > 0 ? (
 						<View style={[{position: 'absolute', right: 0}]}>
-							<Text style={[txt.noto26]}> 댓글 {comments.length - 1}개</Text>
+							<Text style={[txt.noto26]}> 댓글 {data.community_comment_count}개</Text>
 						</View>
 					) : (
 						<></>

--- a/src/component/templete/community/ReviewDetail.js
+++ b/src/component/templete/community/ReviewDetail.js
@@ -221,6 +221,7 @@ export default ReviewDetail = props => {
 							comments => {
 								!parentComment && setComments([]); //댓글목록 초기화
 								let res = comments.msg.filter(e => !e.comment_is_delete || e.children_count != 0);
+								updateCommentsLength(res);
 								let dummyForBox = res[res.length - 1];
 								if (editData.parent != undefined && editData.children_count == 0) {
 									res.map((v, i) => {
@@ -286,6 +287,7 @@ export default ReviewDetail = props => {
 							comments => {
 								!parentComment && setComments([]); //댓글목록 초기화
 								let res = comments.msg.filter(e => !e.comment_is_delete || e.children_count != 0);
+								updateCommentsLength(res);
 								let dummyForBox = res[res.length - 1];
 								res.push(dummyForBox);
 								setComments(res);
@@ -334,6 +336,7 @@ export default ReviewDetail = props => {
 			comments => {
 				// console.log('comments', comments.msg);
 				let res = comments.msg.filter(e => !e.comment_is_delete || e.children_count != 0);
+				updateCommentsLength(res);
 				let dummyForBox = res[res.length - 1];
 				if (parent) {
 					const findIndex = res.findIndex(e => e._id == parent._id);
@@ -367,6 +370,18 @@ export default ReviewDetail = props => {
 				}
 			},
 		);
+	};
+
+	const updateCommentsLength = res => {
+		let commets_length = 0;
+		res.map((v, i) => {
+			commets_length = commets_length + v.children_count;
+			if (v.comment_is_delete) {
+				commets_length--;
+			}
+		});
+		commets_length = commets_length + res.length;
+		data != 'false' ? setData({...data, community_comment_count: commets_length}) : false;
 	};
 
 	const [isReplyFocused, setReplyFocus] = React.useState(false);
@@ -691,7 +706,7 @@ export default ReviewDetail = props => {
 						<Text style={[txt.noto24, {color: GRAY10, marginLeft: 10 * DP}]}>{count_to_K(data.community_like_count)}</Text>
 					</TouchableOpacity>
 					<View style={[style.commentList]}>
-						{comments && comments.length > 0 ? <Text style={[txt.noto26, {textAlign: 'right'}]}> 댓글 {comments.length - 1}개</Text> : <></>}
+						{comments && comments.length > 0 ? <Text style={[txt.noto26, {textAlign: 'right'}]}> 댓글 {data.community_comment_count}개</Text> : <></>}
 					</View>
 				</View>
 			</View>

--- a/src/component/templete/feed/FeedCommentList.js
+++ b/src/component/templete/feed/FeedCommentList.js
@@ -23,6 +23,7 @@ export default FeedCommentList = props => {
 	const [editComment, setEditComment] = React.useState(false); //답글 쓰기 클릭 state
 	const [privateComment, setPrivateComment] = React.useState(false); // 공개 설정 클릭 state
 	const [comments, setComments] = React.useState([]);
+	const [num_of_comment, setNum_of_comment] = React.useState(0);
 	const [commentsLoaded, setCommentsLoaded] = React.useState(false);
 	const [parentComment, setParentComment] = React.useState();
 	const [refresh, setRefresh] = React.useState(true);
@@ -145,10 +146,14 @@ export default FeedCommentList = props => {
 		let comment_count = res.length; //부모 댓글 총개수
 		res.map((v, i) => {
 			comment_count = comment_count + v.children_count; //자식 댓글있으면 부모 댓글 개수에 추가시킴
+			if (v.comment_is_delete) {
+				comment_count--;
+			}
 		});
 		let temp = feed_obj.list; //현재 저장된 리스트
 		const findIndex = temp.findIndex(e => e._id == params.feedobject._id); //현재 보고 있는 피드게시글이 저장된 리스트에서 몇 번째인지
 		temp[findIndex].feed_comment_count = comment_count; //해당 피드게시글의 댓글 개수 갱신
+		setNum_of_comment(comment_count);
 		// let recent = res[0]; //가장 최근 댓글
 		// temp[findIndex].feed_recent_comment = {
 		// 	//해당 피드게시글의 최근 댓글 갱신
@@ -513,7 +518,7 @@ export default FeedCommentList = props => {
 					/>
 					<View style={[{width: 694 * DP, height: 2 * DP, marginTop: 10 * DP, backgroundColor: GRAY40, alignSelf: 'center'}]} />
 					<View style={[{width: 694 * DP, alignSelf: 'center', marginTop: 20 * DP}]}>
-						{comments.length == 0 ? <></> : <Text style={[txt.noto24, {color: GRAY10}]}> 댓글 {comments.length}개</Text>}
+						{comments.length == 0 ? <></> : <Text style={[txt.noto24, {color: GRAY10}]}> 댓글 {num_of_comment}개</Text>}
 					</View>
 				</>
 			);

--- a/src/component/templete/feed/FeedList.js
+++ b/src/component/templete/feed/FeedList.js
@@ -11,7 +11,7 @@ import {
 	PixelRatio,
 	ActivityIndicator,
 	TouchableWithoutFeedback,
-	TouchableOpacity
+	TouchableOpacity,
 } from 'react-native';
 import {APRI10, WHITE} from 'Root/config/color';
 import {Write94, Camera54} from 'Atom/icon';
@@ -147,7 +147,7 @@ export default FeedList = ({route}) => {
 						}, 0);
 						return {
 							...v,
-							offset: route.name == 'MainHomeFeedList'?offset+276*DP:offset,
+							offset: route.name == 'MainHomeFeedList' ? offset + 276 * DP : offset,
 						};
 					}),
 			);
@@ -560,7 +560,7 @@ export default FeedList = ({route}) => {
 	};
 	const [viewIndex, setViewIndex] = React.useState([]);
 	const renderItem = ({item, index}) => {
-		return <Feed data={item} deleteFeed={deleteFeedItem} isView={focused&& viewIndex == index} onPressPhoto={onPressPhoto} />;
+		return <Feed data={item} deleteFeed={deleteFeedItem} isView={focused && viewIndex == index} onPressPhoto={onPressPhoto} />;
 		// return (focused&&<View style={{backgroundColor:viewIndex==index?'red':'blue'}}><Feed data={item} deleteFeed={deleteFeedItem} isView={focused&&viewIndex==index}/></View>);
 	};
 
@@ -572,7 +572,7 @@ export default FeedList = ({route}) => {
 		setRefreshing(true);
 		wait(0).then(() => setRefreshing(false));
 	};
-	
+
 	const rememberScroll = e => {
 		if (e.nativeEvent.contentOffset.y > 0) {
 			userGlobalObject.t = e.nativeEvent.contentOffset;
@@ -648,44 +648,34 @@ export default FeedList = ({route}) => {
 				/>
 			}
 			{userGlobalObject.userInfo && (
-				<View style={[{position: 'absolute', bottom: 40 * DP, right: 30 * DP}]}>
-					{/* <View
-						style={[
-							{
-								height: 94 * DP,
-								width: 94 * DP,
-								justifyContent: 'center',
-								alignItems: 'center',
-								backgroundColor: '#FFF',
-								borderRadius: 30 * DP,
-								marginBottom: 20 * DP,
-							},
-							buttonstyle.shadow,
-						]}>
-						<Camera54 onPress={movetoCamera} />
-					</View> */}
-
-					<View
-						style={[
-							{
-								height: 94 * DP,
-								width: 94 * DP,
-								justifyContent: 'center',
-								alignItems: 'center',
-								backgroundColor: '#ff9888',
-								borderRadius: 35 * DP,
-								marginBottom: 20 * DP,
-							},
-							buttonstyle.shadow,
-						]}>
-						<Write94 onPress={moveToFeedWrite} />
-					</View>
+				<View
+					style={[
+						{
+							position: 'absolute',
+							bottom: 40 * DP,
+							right: 30 * DP,
+							height: 94 * DP,
+							width: 94 * DP,
+							justifyContent: 'center',
+							alignItems: 'center',
+							backgroundColor: '#ff9888',
+							borderRadius: 35 * DP,
+						},
+						buttonstyle.shadow,
+					]}>
+					<Write94 onPress={moveToFeedWrite} />
 				</View>
 			)}
 			{/*센트리오류 테스트*/}
-			{false&&<TouchableOpacity onPress={()=>{console.log(androidError)}} style={{width:100,height:100,backgroundColor:'yellow',position:'absolute'}}>
-				<View style={{width:100,height:100,backgroundColor:'blue',position:'absolute'}}></View>
-				</TouchableOpacity>}
+			{false && (
+				<TouchableOpacity
+					onPress={() => {
+						console.log(androidError);
+					}}
+					style={{width: 100, height: 100, backgroundColor: 'yellow', position: 'absolute'}}>
+					<View style={{width: 100, height: 100, backgroundColor: 'blue', position: 'absolute'}}></View>
+				</TouchableOpacity>
+			)}
 			{false && (
 				<View style={{backgroundColor: 'red', width: 750 * DP, top: 0, position: 'absolute'}}>
 					<View style={{backgroundColor: 'yellow', marginBottom: 20}}>

--- a/src/component/templete/feed/FeedWrite.js
+++ b/src/component/templete/feed/FeedWrite.js
@@ -413,7 +413,7 @@ export default FeedWrite = props => {
 	const render = ({item, index}) => {
 		return (
 			<View style={[login_style.wrp_main]} ref={container}>
-				{!(showLostAnimalForm || showReportForm) && (
+				{props.route.params.feedType == 'Feed' && !(showLostAnimalForm || showReportForm) && (
 					<View style={{width: '100%'}}>
 						<View
 							style={{
@@ -447,6 +447,7 @@ export default FeedWrite = props => {
 						{!isSearchTag && setWriteModeState()}
 					</View>
 				)}
+
 				{/* 긴급 게시 관련 버튼 클릭 시 출력되는 View */}
 				{setUrgBtnsClickedView()}
 			</View>

--- a/src/component/templete/missing/MissingReportList.js
+++ b/src/component/templete/missing/MissingReportList.js
@@ -25,8 +25,6 @@ export default MissingReportList = props => {
 	const [filterData, setFilterData] = React.useState({city: ''});
 	const [onlyMissing, setOnlyMissing] = React.useState(false); //실종글만 보기
 	const [onlyReport, setOnlyReport] = React.useState(false); // 제보글만 보기
-	const [pressed, setPressed] = React.useState(false);
-	const urgentBtnRef = React.useRef();
 
 	React.useEffect(() => {
 		getList();
@@ -107,11 +105,13 @@ export default MissingReportList = props => {
 
 	//제보 게시글 쓰기 클릭
 	const moveToReportForm = () => {
+		Modal.close();
 		navigation.navigate('FeedWrite', {feedType: 'Report', tab: 'Protection'});
 	};
 
 	//실종 게시글 쓰기 클릭
 	const moveToMissingForm = () => {
+		Modal.close();
 		navigation.navigate('FeedWrite', {feedType: 'Missing', tab: 'Protection'});
 	};
 
@@ -204,11 +204,8 @@ export default MissingReportList = props => {
 				navigation.navigate('LoginRequired');
 			});
 		} else {
-			setPressed(true);
-			// setShowActionButton(!showActionButton);
-			setTimeout(() => {
-				Modal.popUrgentBtnModal(moveToReportForm, moveToMissingForm, urgentBtnRef.current, () => setPressed(false));
-			}, 150);
+			// set(true);
+			Modal.popUrgentBtnModal(moveToReportForm, moveToMissingForm, {}, () => {});
 		}
 	};
 
@@ -315,8 +312,8 @@ export default MissingReportList = props => {
 				)}
 			</View>
 
-			<View style={[pressed ? feedWrite.urgentBtnContainer2 : feedWrite.urgentBtnContainer]}>
-				<View style={[styles.urgentActionButton]} onLayout={e => (urgentBtnRef.current = e.nativeEvent.layout)}>
+			<View style={[feedWrite.urgentBtnContainer]}>
+				<View style={[styles.urgentActionButton]}>
 					<TouchableOpacity onPress={onPressShowActionButton}>
 						<Urgent_Write1 />
 					</TouchableOpacity>

--- a/src/component/templete/protection/AnimalProtectRequestDetail.js
+++ b/src/component/templete/protection/AnimalProtectRequestDetail.js
@@ -31,6 +31,7 @@ export default AnimalProtectRequestDetail = ({route}) => {
 	const [writersAnotherRequests, setWritersAnotherRequests] = React.useState('false'); //해당 게시글 작성자의 다른 보호요청게시글 목록(현재 글 제외)
 	const [total, setTotal] = React.useState(0); //해당 게시글 작성자의 보호요청게시글 작성글 총 개수
 	const [comments, setComments] = React.useState('false'); //comment list 정보
+	const [num_of_comments, setNum_of_comments] = React.useState(0);
 	const [offset, setOffset] = React.useState(1);
 	const [pressed, setPressed] = React.useState(false);
 	const isShelter = userGlobalObject.userInfo.user_type == 'shelter';
@@ -158,7 +159,6 @@ export default AnimalProtectRequestDetail = ({route}) => {
 					//일반 피드글과 구분하기 위해 feed_type 속성 추가 (다른 템플릿들과 시간 표기가 달라서 실종/제보에만 feed_type을 추가하고 시간 표기시 해당 속성 존재 여부만 판단)
 					comments.msg[i].feed_type = 'report';
 				});
-
 				//댓글과 대댓글 작업 (부모 댓글과 자식 댓글 그룹 형성- 부모 댓글에서 부모의 childArray 속성에 자식 댓글 속성들을 추가)
 				//부모 댓글은 실제 삭제불가하며 필드로 삭제 여부 값 형성 필요. (네이버나 다음 까페에서도 대댓글 존재시 댓글은 삭제해도 댓글 자리는 존재하고 그 밑으로 대댓글 그대로 노출됨)
 				let commentArray = [];
@@ -181,6 +181,7 @@ export default AnimalProtectRequestDetail = ({route}) => {
 					}
 				});
 				let res = commentArray.filter(e => !e.comment_is_delete || e.children_count != 0);
+				updateCommentsLength(res);
 				setComments(res);
 				//댓글이 출력이 안되는 현상 발견으로 비동기 처리
 			},
@@ -192,6 +193,19 @@ export default AnimalProtectRequestDetail = ({route}) => {
 				setComments([]);
 			},
 		);
+	};
+
+	//댓글 개수 갱신
+	const updateCommentsLength = res => {
+		let comments_length = 0;
+		res.map((v, i) => {
+			comments_length = comments_length + v.children_count;
+			if (v.comment_is_delete) {
+				comments_length--;
+			}
+		});
+		comments_length = comments_length + res.length;
+		setNum_of_comments(comments_length);
 	};
 
 	//보호요청 더보기의 Thumnail클릭
@@ -405,7 +419,7 @@ export default AnimalProtectRequestDetail = ({route}) => {
 
 				{comments && comments.length > 0 ? (
 					<TouchableOpacity onPress={moveToCommentPage} style={[style.replyCountContainer]}>
-						<Text style={[txt.noto26, {color: GRAY10}]}> 댓글 {comments.length}개 모두 보기</Text>
+						<Text style={[txt.noto26, {color: GRAY10}]}> 댓글 {num_of_comments}개 모두 보기</Text>
 					</TouchableOpacity>
 				) : (
 					<></>

--- a/src/component/templete/protection/ProtectCommentList.js
+++ b/src/component/templete/protection/ProtectCommentList.js
@@ -19,6 +19,7 @@ export default ProtectCommentList = props => {
 	const [editComment, setEditComment] = React.useState(false); //답글 쓰기 클릭 state
 	const [privateComment, setPrivateComment] = React.useState(false); // 공개 설정 클릭 state
 	const [comments, setComments] = React.useState([]);
+	const [num_of_comments, setNum_of_comments] = React.useState(0);
 	const [parentComment, setParentComment] = React.useState();
 	const [refresh, setRefresh] = React.useState(true);
 	const [heightReply, setReplyHeight] = React.useState(0); //키보드 리플박스 높이
@@ -66,6 +67,7 @@ export default ProtectCommentList = props => {
 			},
 			comments => {
 				let res = comments.msg.filter(e => !e.comment_is_delete || e.children_count != 0);
+				updateCommentsLength(res);
 				if (parent) {
 					const findIndex = res.findIndex(e => e._id == parent._id); //댓글 삭제 후
 					res.map((v, i) => {
@@ -144,6 +146,7 @@ export default ProtectCommentList = props => {
 							comments => {
 								!parentComment && setComments([]); //댓글목록 초기화
 								let res = comments.msg.filter(e => !e.comment_is_delete || e.children_count != 0);
+								updateCommentsLength(res);
 								if (editData.parent != undefined && editData.children_count == 0) {
 									res.map((v, i) => {
 										res[i].isEdited = i == editData.parent ? true : false;
@@ -194,6 +197,7 @@ export default ProtectCommentList = props => {
 							comments => {
 								!parentComment && setComments([]); //댓글목록 초기화
 								let res = comments.msg.filter(e => !e.comment_is_delete || e.children_count != 0);
+								updateCommentsLength(res);
 								setComments(res);
 								setPrivateComment(false);
 								setEditMode(false);
@@ -226,6 +230,19 @@ export default ProtectCommentList = props => {
 				);
 			}
 		}
+	};
+
+	//댓글 개수 갱신
+	const updateCommentsLength = res => {
+		let comments_length = 0;
+		res.map((v, i) => {
+			comments_length = comments_length + v.children_count;
+			if (v.comment_is_delete) {
+				comments_length--;
+			}
+		});
+		comments_length = comments_length + res.length;
+		setNum_of_comments(comments_length);
 	};
 
 	//페이지 상단 보호소 프로필 클릭
@@ -466,7 +483,7 @@ export default ProtectCommentList = props => {
 				</View>
 				<View style={{height: 2 * DP, width: 694 * DP, backgroundColor: GRAY40, marginVertical: 30 * DP}}></View>
 				<View style={{alignItems: 'flex-end', width: 694 * DP}}>
-					{comments.length == 0 ? <></> : <Text style={[txt.noto26, {color: GRAY10}]}>댓글 {comments.length}개 </Text>}
+					{comments.length == 0 ? <></> : <Text style={[txt.noto26, {color: GRAY10}]}>댓글 {num_of_comments}개 </Text>}
 				</View>
 			</View>
 		);

--- a/src/component/templete/user/AskQuestion.js
+++ b/src/component/templete/user/AskQuestion.js
@@ -1,8 +1,7 @@
 import {useNavigation} from '@react-navigation/core';
 import React from 'react';
-import {Text, View, ScrollView, TouchableOpacity, TextInput, ActivityIndicator, StyleSheet} from 'react-native';
+import {Text, View, ScrollView, TextInput, ActivityIndicator, StyleSheet} from 'react-native';
 import {BLACK, MAINBLACK} from 'Root/config/color';
-import {txt} from 'Root/config/textstyle';
 import DP from 'Root/config/dp';
 import Modal from 'Component/modal/Modal';
 import SelectInput from 'Component/molecules/button/SelectInput';
@@ -11,7 +10,6 @@ import AniButton from 'Component/molecules/button/AniButton';
 import {btn_w654, btn_w694_r30} from 'Component/atom/btn/btn_style';
 import {getCommonCodeDynamicQuery} from 'Root/api/commoncode';
 import {createQandA} from 'Root/api/qanda';
-import {assignCheckListItem} from 'Root/component/organism/style_organism copy';
 
 // 필요한 데이터 - 로그인 유저 제반 데이터, 나의 반려동물 관련 데이터(CompanionObject 참조)
 const AskQuestion = ({route}) => {
@@ -65,6 +63,7 @@ const AskQuestion = ({route}) => {
 	const onChangeText = text => {
 		setContents(text);
 	};
+
 	const onChangeTitle = text => {
 		setTitle(text);
 	};
@@ -73,17 +72,13 @@ const AskQuestion = ({route}) => {
 		setUserAgreement(isCheck);
 	};
 
-	React.useEffect(() => {
-		console.log('user', userAgreement);
-	}, [userAgreement]);
-
 	const onPressDetail = index => {
 		console.log(index + 'index 항목 더보기 클릭');
 		Modal.popOneBtn('적용 예정입니다.', '확인', () => Modal.close());
 	};
 
 	const onPressAsk = () => {
-		console.log('어쩌고저쩌고', userAgreement, category, contents, title);
+		// console.log('어쩌고저쩌고', userAgreement, category, contents, title);
 		// if (userAgreement && category != '카테고리 선택' && contents && title) {
 		if (category != '카테고리 선택' && contents && title) {
 			for (let i in commomCode) {
@@ -115,17 +110,16 @@ const AskQuestion = ({route}) => {
 			// else if (category == '카테고리 선택') {
 			if (category == '카테고리 선택') {
 				Modal.alert('문의 카테고리를 선택해주세요.');
-			} else if (!contents && contents.length == 0) {
+			} else if (contents == undefined) {
 				Modal.alert('문의 내용을 적어주세요.');
 			} else if (!title) {
 				Modal.alert('제목을 입력해주세요.');
 			}
-			// Modal.popOneBtn('입력을 확인해주세요', '확인', () => Modal.close());
 		}
 	};
+
 	const onCheck = isCheck => {
 		setUserAgreement(isCheck);
-		// props.onCheck(isCheck);
 	};
 
 	if (loading) {

--- a/src/component/templete/user/ReceivedMessage.js
+++ b/src/component/templete/user/ReceivedMessage.js
@@ -115,7 +115,9 @@ export default ReceivedMessage = ({route}) => {
 				{user_object_id: v.opponent},
 				result => {
 					// console.log('delelteMemoBoxWithUser success', result);
-					getMemoBoxListFunction();
+					if (i == copy.length - 1) {
+						getMemoBoxListFunction();
+					}
 				},
 				err => {
 					console.log('deleteMomoBoxWithUser err', err);

--- a/src/component/templete/user/UserNotePage.js
+++ b/src/component/templete/user/UserNotePage.js
@@ -53,6 +53,7 @@ const UserNotePage = ({route}) => {
 
 	const onWrite = () => {
 		if (content.trim() == '') return Modal.popOneBtn('채팅을 입력하세요.', '확인', () => Modal.close());
+		input.current?.blur();
 		createMemoBox(
 			{memobox_receive_id: route.params._id, memobox_contents: content},
 			result => {


### PR DESCRIPTION
*수정 사항:
*수정 결과
*수정 파일: 
1) App.js
- ios의 기종별 bottom notch height값을 얻기 위한 코드 추가

2) src/component/molecules/modal/AvatarSelectFromWriteModal.js
     src/component/molecules/modal/UrgentBtnModal.js
     src/component/templete/feed/FeedList.js
     src/component/templete/missing/MissingReportList.js
- 피드리스트 및 실종/제보 리스트 화면에서 글쓰기 클릭시 출력되는 모달의 위치가 특정 디바이스에서 비정상적으로 출력되던 현상 수정

3) src/component/molecules/modal/OneButtonSelectModal.js
- 신고하기 카테고리 스크롤 후 완료 버튼 클릭시 상단 선택 아이템 텍스트가 갱신되지 않던 현상 수정

4)  src/component/organism/list/NoteMessageList.js
- 쪽지를 보낼 때마다 스크롤이 갱신되도록 적용

5) src/component/templete/community/ArticleDetail.js
     src/component/templete/community/ReviewDetail.js
     src/component/templete/feed/FeedCommentList.js
      src/component/templete/protection/AnimalProtectRequestDetail.js
- 상세 페이지에서 댓글의 개수가 부모댓글만 참조 => 대댓글도 포함되도록 수정

6) src/component/templete/feed/FeedWrite.js
-  글쓰기 화면에서 일반피드 글쓰기 레이아웃이 잠시간 출력되었다가 실종,제보 입력폼으로 바뀌던 현상발견
   => 실종,제보 폼이 출력되고 레이아웃이 그려지도록 변경(깜빡거림 제거)


7) src/component/templete/user/AskQuestion.js
- 정보/문의 > 고객센터 > 문의하기 > 카테고리 선택 > 제목 입력 > 문의 내용은 비운 채로 문의 접수 > 앱 강제종료 오류 수정

8) src/component/templete/user/ReceivedMessage.js
- 2개 이상의 쪽지 삭제 시 쪽지리스트 갱신을 매 루프마다 하던 문제 개선

9) src/component/templete/user/UserNotePage.js
- 쪽지 보내기 후 키보드가 종료 되도록 수정